### PR TITLE
确保 PDF 导出自动包含《前言》

### DIFF
--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -13,8 +13,9 @@ cd tools/pdf_export && python -m pdf_export
 1. 读取 `README.md` 中的目录结构，确保 PDF 的目录页与 README 保持一致；
 2. 若 `README.md` 未提供目录（或被忽略掉），脚本会自动按 `entries/` 下的实际目录与文件构建一个后备目录结构；
 3. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
-4. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；
-5. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
+4. 在合并内容前，会优先插入项目根目录下的 `前言.md`（若存在且未被忽略），以确保 PDF 以《前言》开篇；
+5. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；
+6. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 运行脚本前，请确保：
 

--- a/tools/pdf_export/pdf_export/structure.py
+++ b/tools/pdf_export/pdf_export/structure.py
@@ -52,6 +52,17 @@ def collect_markdown_structure(ignore: IgnoreRules) -> CategoryStructure:
     """Collect markdown files following the README index order."""
 
     categories = list(parse_readme_index(README_PATH, ignore))
+    listed_paths = {path for _, paths in categories for path in paths}
+
+    # 项目根目录下的《前言》应在 PDF 中最先展示。
+    preface_path = PROJECT_ROOT / "前言.md"
+    if (
+        preface_path.exists()
+        and not ignore.matches(preface_path)
+        and preface_path not in listed_paths
+    ):
+        categories.insert(0, ("前言", (preface_path,)))
+
     if categories:
         return tuple(categories)
 


### PR DESCRIPTION
## Summary
- 在生成导出结构时自动将项目根目录下的《前言》置于所有词条之前
- 更新 PDF 导出使用说明，明确会优先插入 `前言.md`

## Testing
- python -m compileall tools/pdf_export/export_to_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68dbec3c3bd883339658864657c54e62