### PR TITLE
更新管理者（Admin）词条

### DIFF
--- a/entries/系统角色与类型/管理者.md
+++ b/entries/系统角色与类型/管理者.md
@@ -1,42 +1,54 @@
 # 管理者（Admin）
 
-**这个词条翻译自其他多意识体 Wiki。**
+**一句话定义**：**管理者**指在多意识体或解离性系统中承担维护整体运作、调配资源与信息流的内部角色，常被视为系统的“运营中枢”。
 
-_该条目可能需要时常从其[来源](https://pluralpedia.org/w/Admin)更新。_
-本词条遵循[CC BY-SA3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.zh-hans)协议。
+> 本词条参考了社区资料（如 Pluralpedia）与公开文献，并补充了对临床术语“内部自助者”等角色的对应关系。资料遵循 [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.zh-hans) 协议。
 
-## 定义
+## 核心职责
 
-**管理者**是指一类会执行内部任务来提高系统自持能力的系统角色。
+- **维持运作**：规划前台/后台的切换、监控成员状态，尽量保持日常生活的稳定度与安全性。
+- **信息管理**：记录或整理记忆、内在规则、系统史，必要时协调信息共享或设定访问权限。
+- **沟通协调**：组织系统成员间的沟通渠道、仲裁冲突、监督共识执行，帮助系统形成一致的对外回应。
+- **风险应对**：在危机、触发或重大决策时进行评估与响应，可能与守门人、保护者等角色配合。
 
-## 简介
+以上职能可由单一管理者承担，也可能分散到多个具有不同专长的管理者小组中。部分系统会把具有行政职能的角色集中到独立“后台”或子系统中运行，降低对前台功能的干扰。[^管理者-1]
 
-管理者会维护系统的正常运行。
+## 机制与功能假设
 
-管理者是一类系统角色的统称。这意味着它们的具体角色是模糊的，并且有着多种多样、内容广阔的任务，包括：
+- **知识与访问优势**：管理者常被描述为拥有对系统结构、成员信息或外界记忆的较高访问权限，可在必要时调取或封存记忆，以保障整体运作的连续性。[^PluralpediaAdmin]
+- **内在自助者的延伸**：临床文献中提出的“内部自助者”（Internal Self Helper, ISH）被视为一种具有高度洞察力、能协助治疗者协调内部沟通的角色，与社区语境中的管理者存在功能重叠；研究指出 ISH 能帮助收集信息、组织内部会议并辅助危机干预。[^Kluft1985][^Loewenstein1993]
+- **元管理能力**：一些系统会让管理者承担规则制定、权限配置等“元层级”任务，使其类似“系统管理员”，在结构演化或合并/分离过程中提供监督与审核。[^AlterWiki]
 
-- 控制前台、后台的切换
+这些描述多来自个案报告与系统自述，具体表现受系统规模、创伤史、社群语境等影响，并无统一的诊断标准或必要特征。[^Loewenstein1993]
 
-- 记录系统的信息
+## 与其他角色的区分
 
-- 控制或影响系统的一部分（和里世界）
+- **守门人（Gatekeeper）**：通常关注前台访问与解离屏障，侧重开关权限；管理者的范围更广，可能包含制度化的协调工作。
+- **内部自助者（ISH）**：在临床治疗中强调与治疗者合作；管理者则不一定参与外部治疗，但往往承担类似的协调与信息整合职能。
+- **领导者/系统组织者**：更偏向制定方向或代表系统发声，管理者则关注流程与执行。部分角色可能同时兼任。
 
-- 组织系统成员之间的沟通
+## 临床与社区视角
 
-- 同步不同系统成员的记忆
+- **社区语境**：Pluralpedia 与 Wikipedia 等资料把管理者视作多意识系统的常见行政角色，用来描述具有计划、记录、调度任务的成员。[^PluralpediaAdmin][^AlterWiki]
+- **临床语境**：治疗者在 DID/OSDD 个案中会寻找内部自助者或类似的协调角色，作为治疗联盟与安全计划的重要资源；研究显示此类角色能帮助整合信息、引导其他部分参与治疗。[^Kluft1985][^Loewenstein1993]
+- **跨语境沟通**：当系统成员以“管理员”身份与治疗者或支持网络交流时，建议明确说明具体职能（如记忆管理、危机协调），以避免被误解为单纯的“掌控欲”或外部权威。
 
-等等。
+## 相关条目
 
-一个管理者可能会有多种不同的职责，这和他们的不同的角色有关。常见的管理者可能同时兼任的角色类型有守门人、规则制定者、记忆保管员和系统普查员。
+- 守门人（Gatekeeper）
+- [内部自助者（ISH）](entries/系统角色与类型/内部自助者.md)
+- [权限（Permissions）](entries/系统体验与机制/权限.md)
+- [伪主体（Fauxmain）](entries/系统角色与类型/伪主体.md)
 
-管理者不常常切换到前台来，这一点在大型的系统中尤为常见。此时他们作为完全的系统内部角色而运作。他们可以拥有了解所有成员记忆的权限，然后保管一些其他系统成员完全没有意识到的信息。
+## 参考与延伸阅读
 
-偶尔，管理者可能位于系统其他部分的独立系统[^管理者-1]中，这些独立的系统可能无法与其他系统正常交流。
+- Wikipedia contributors. (2024, January). *Alter (dissociative identity disorder)*. In Wikipedia, The Free Encyclopedia. https://en.wikipedia.org/wiki/Alter_(dissociative_identity_disorder)
+- Kluft, R. P. (1985). The "Inner Self Helper" in multiple personality disorder. *International Journal of Clinical and Experimental Hypnosis, 33*(3), 198–221. https://doi.org/10.1080/00207148508407277
+- Loewenstein, R. J. (1993). Diagnosis, epidemiology, clinical course, and treatment of multiple personality disorder. *Psychiatric Clinics of North America, 16*(3), 543–570.
+- Pluralpedia. (2024). *Admin*. https://pluralpedia.org/w/Admin
 
-## 相关内容
-
-- 由于管理者的职责多样，他们有多种可能的角色，例如内部自助者，领导者或者系统组织员。
-
-## 参考资料
-
-[^管理者-1]: 原文为 sisasystem，来自[Sisasystem - Pluralpedia](https://pluralpedia.org/w/Sisasystem)
+[^管理者-1]: 原文为 sisasystem，来自 [Sisasystem - Pluralpedia](https://pluralpedia.org/w/Sisasystem)。
+[^AlterWiki]: Wikipedia contributors. (2024, January). *Alter (dissociative identity disorder)*. In Wikipedia, The Free Encyclopedia. https://en.wikipedia.org/wiki/Alter_(dissociative_identity_disorder)
+[^PluralpediaAdmin]: Pluralpedia. (2024). *Admin*. https://pluralpedia.org/w/Admin
+[^Kluft1985]: Kluft, R. P. (1985). The "Inner Self Helper" in multiple personality disorder. *International Journal of Clinical and Experimental Hypnosis, 33*(3), 198–221. https://doi.org/10.1080/00207148508407277
+[^Loewenstein1993]: Loewenstein, R. J. (1993). Diagnosis, epidemiology, clinical course, and treatment of multiple personality disorder. *Psychiatric Clinics of North America, 16*(3), 543–570.


### PR DESCRIPTION
## Summary
- 重写管理者词条结构，明确职责、机制与跨语境差异
- 引入 Pluralpedia、Wikipedia 及临床论文作为参考并补充脚注

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc03ff77c083338f9a224119bc8ee3