### PR TITLE
修正 OSDD 词条中非正式分类的表述

### DIFF
--- a/entries/诊断与临床/其他特定解离性障碍.md
+++ b/entries/诊断与临床/其他特定解离性障碍.md
@@ -19,7 +19,9 @@ _仅供参考，**不能**替代专业医师的诊断和治疗方案。如果有
 
 ## 常见的 OSDD 类型（DSM-5 示例）
 
-DSM-5 给出了几个典型的“例子”，说明哪些情况会被诊断为 OSDD：
+DSM-5 与 DSM-5-TR 在文字说明中给出了几个典型的“例子”，帮助临床人员理解哪些情况会被诊断为 OSDD；它们并非正式的亚型或独立分类。
+
+> 历史上，部分作者与同侪支持社区曾使用 “OSDD-1a”“OSDD-1b” 等非正式标签，来指代以下几个例子中的不同表现。但在最新版的 DSM-5-TR 中，这些编号从未被列为正式诊断或说明语，仅能作为个案描述的便捷说法。为了避免误导，本词条不再把它们当作独立类别。[^Brand2021][^OSDDWiki]
 
 1. **慢性或反复性混乱 / 交替的身份状态**
    - 但 **没有显著遗忘**（即不符合 DID 的记忆缺失要求）。
@@ -35,11 +37,13 @@ DSM-5 给出了几个典型的“例子”，说明哪些情况会被诊断为 O
 5. **混合性解离症状**
    - 存在多种解离症状，但无法归入某一个确切类别。
 
+[^Brand2021]: Brand, B. L., & Loewenstein, R. J. (2021). Dissociative disorders: An overview of assessment, phenomenology, and treatment. _Journal of Psychiatric Practice_, 27(3), 170–182.
+[^OSDDWiki]: “Other specified dissociative disorder.” _Wikipedia_, 2024 年 5 月更新，https://en.wikipedia.org/wiki/Other_specified_dissociative_disorder。
+
 ---
 
 ## 与其他障碍的区别
 
 - **解离性身份障碍（DID）**：必须存在两个或以上身份状态，并伴随反复的记忆缺失。
-- **OSDD-1a**：身份状态混乱，但无显著遗忘。
-- **OSDD-1b**：存在解离性遗忘，但不足以满足 DID 的诊断标准。
+- **OSDD 个案**：可能在身份状态、遗忘或附体体验上表现出 DID 的部分特征，但症状强度或频率不足以满足 DID 的全部标准。
 - **人格解体 / 现实解体障碍**：核心是与自我或现实脱节，而非身份混乱。


### PR DESCRIPTION
## Summary
- 说明 DSM-5 与 DSM-5-TR 中列举的 OSDD 案例并非正式亚型
- 标注 OSDD-1a/1b 等标签仅为历史上常用的非正式称呼
- 更新与 DID 等障碍的比较描述，避免误导性分类

## Testing
- 未进行自动化测试（文档改动）

------
https://chatgpt.com/codex/tasks/task_e_68dc080d4aa88333a872fdebd7bf2fed