### PR TITLE
feat: 为 GitHub Pages 添加 Docsify 首页

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ tools/
 
 ---
 
+## 在线浏览（Docsify + GitHub Pages）
+
+- **直接预览**：仓库根目录新增的 [`index.html`](index.html) 基于 Docsify，即可在任何静态服务器或 GitHub Pages 中即时渲染 Markdown。推送到 `main` 分支后，在仓库的 “Settings → Pages” 中选择 `Deploy from a branch` 与根目录（`/`），即可获得在线阅读地址。
+- **国内访问提示**：Docsify 依赖 jsDelivr 的 CDN，国内偶尔会存在访问波动。如需更稳定的访问速度，可在自己的分叉中改用 [unpkg](https://unpkg.com/docsify) 或配置自托管的静态资源。
+- **本地验证**：若需在本地检视样式，推荐使用 Docsify 官方 CLI（`npx docsify serve .`）或任意静态服务器（如 `python -m http.server`）启动预览，再访问 `http://localhost:3000`（或对应端口）。
+
+---
+
 ## 词条索引（Index）
 
 索引内容已迁移至独立的 [`index.md`](index.md)，方便独立维护与浏览。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <title>plurality_wiki</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Docsify -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/themes/vue.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'plurality_wiki',
+      repo: 'kuliantnt/plurality_wiki',
+      homepage: 'index.md',
+      loadSidebar: false,
+      loadNavbar: false,
+      subMaxLevel: 2,
+      auto2top: true,
+      relativePath: true
+    };
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 新增 Docsify 驱动的 `index.html`，支持在静态托管或 GitHub Pages 上直接渲染 Markdown。
- 在 README 中补充 Docsify/GitHub Pages 的部署、访问与本地预览提示。

## Testing
- 未执行（文档改动）

------
https://chatgpt.com/codex/tasks/task_e_68dca7f1fe38833398b31c3d9ed4bef6