### PR TITLE
修复 Docsify 首页与导航加载

### DIFF
--- a/_navbar.md
+++ b/_navbar.md
@@ -1,4 +1,4 @@
 * 快速入口
-  * 首页 (README.md)
-  * 术语索引 (index.md)
-  * GitHub 仓库 (https://github.com/kuliantnt/plurality_wiki)
+  * [首页](README_wiki.md)
+  * [术语索引](index.md)
+  * [GitHub 仓库](https://github.com/kuliantnt/plurality_wiki)

--- a/index.html
+++ b/index.html
@@ -36,6 +36,11 @@
         return base;
       })();
 
+      const alias = {
+        '/.*/_navbar.md': '_navbar.md',
+        '/.*/_sidebar.md': '_sidebar.md',
+      };
+
       window.$docsify = {
         name: "多意识体Wikipedia",
         repo: "kuliantnt/plurality_wiki",


### PR DESCRIPTION
## 改动动机
- GitHub Pages 站点未正确加载 Docsify，默认展示 README.md，且顶栏导航无法显示。

## 主要变更
- 在 `index.html` 中补充 Docsify `alias` 配置，修复脚本错误并确保 `_navbar.md`、`_sidebar.md` 可在任意路径下加载。
- 调整 `_navbar.md` 链接语法，使首页指向 `README_wiki.md` 并保证链接可点击。

## 潜在风险
- 变更为前端静态配置，风险较低；如需进一步验证，可通过 `npx docsify serve .` 本地预览。

## 相关条目或链接
- https://kuliantnt.github.io/plurality_wiki/


------
https://chatgpt.com/codex/tasks/task_e_68dcc16e88cc8333bdf8f7e16870dad9