### PR TITLE
修复 PDF 导出重复标题问题

### DIFF
--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -14,7 +14,7 @@ cd tools/pdf_export && python -m pdf_export
 2. 若索引缺失或被忽略，脚本会回退至 `README.md`，如两者均不可用则按 `entries/` 目录实际文件构建后备目录结构；
 3. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
 4. 在合并内容前，会优先插入项目根目录下的 `前言.md`（若存在且未被忽略），以确保 PDF 以《前言》开篇；
-5. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；
+5. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；在合并过程中会自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
 6. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 运行脚本前，请确保：

--- a/tools/pdf_export/pdf_export/markdown.py
+++ b/tools/pdf_export/pdf_export/markdown.py
@@ -72,7 +72,7 @@ def build_entry_anchor(path: Path) -> str:
 def strip_primary_heading(content: str, title: str) -> str:
     """Remove the first heading that matches ``title`` from ``content``."""
 
-    heading_re = re.compile(rf"^#{1,6}\s+{re.escape(title)}\s*$")
+    heading_re = re.compile(rf"^#{{1,6}}\s+{re.escape(title)}\s*$")
     lines = content.splitlines()
     stripped: list[str] = []
     removed = False


### PR DESCRIPTION
## 改动动机
- 解决 PDF 导出后目录成员出现重复标题的问题，例如《退行（Regression in Psychology）》在正文中重复显示两次。

## 主要变更
- 修正合并 Markdown 时用于剥离原始一级标题的正则表达式，确保不会把重复标题保留在正文中。
- 在导出说明中补充“自动移除原始一级标题”机制的说明，帮助维护者理解行为。

## 潜在风险
- 该修改仅影响标题剥离逻辑，理论风险较低，但仍需在实际导出流程中确认无其他副作用。

## 相关条目或链接
- 《退行（Regression in Psychology）》等受影响的 PDF 导出条目。

------
https://chatgpt.com/codex/tasks/task_e_68dccc5703c08333b646bf4e50582d51