### PR TITLE
修复 Docsify 哈希路径归一化问题

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,11 +32,8 @@
           "/.*/_sidebar.md": "_sidebar.md",
         };
 
-        const canonicalizeHash = () => {
-          const { hash } = window.location;
-          if (!hash || !hash.startsWith("#/")) return;
-
-          const [rawPath, query = ""] = hash.slice(2).split("?");
+        const normalizePath = (raw) => {
+          const [rawPath, query = ""] = raw.split("?");
           const segments = rawPath.split("/").filter(Boolean);
           const stack = [];
 
@@ -49,15 +46,50 @@
           }
 
           const normalizedPath = stack.join("/");
-          const normalizedHash =
-            "#/" + normalizedPath + (query ? `?${query}` : "");
-
-          if (normalizedHash !== hash) {
-            history.replaceState(null, "", normalizedHash);
-          }
+          return normalizedPath + (query ? `?${query}` : "");
         };
 
-        window.addEventListener("hashchange", canonicalizeHash);
+        const canonicalizeHash = (() => {
+          let adjusting = false;
+
+          const updateHash = (hash, notifyRouter) => {
+            const { origin, pathname, search } = window.location;
+            const newUrl = `${origin}${pathname}${search}${hash}`;
+
+            adjusting = true;
+            history.replaceState(null, "", newUrl);
+
+            if (notifyRouter) {
+              const event =
+                typeof HashChangeEvent === "function"
+                  ? new HashChangeEvent("hashchange")
+                  : new Event("hashchange");
+              window.dispatchEvent(event);
+            }
+
+            adjusting = false;
+          };
+
+          return (notifyRouter = false) => {
+            if (adjusting) return;
+
+            const { hash } = window.location;
+            if (!hash || !hash.startsWith("#/")) return;
+
+            const normalizedPath = normalizePath(hash.slice(2));
+            const normalizedHash = `#/${normalizedPath}`;
+
+            if (normalizedHash !== hash) {
+              updateHash(normalizedHash, notifyRouter);
+            }
+          };
+        })();
+
+        window.addEventListener(
+          "hashchange",
+          () => canonicalizeHash(true),
+          true
+        );
         canonicalizeHash();
 
         window.$docsify = {


### PR DESCRIPTION
## 摘要
- 调整 index.html 的哈希路径归一化逻辑，新增通用 normalizePath 函数
- 通过 replaceState 搭配自定义 hashchange 事件，确保含有 .. 的相对链接自动转为规范路径

## 风险
- 较低：修改仅作用于 Docsify 路由哈希的归一化流程

## 测试
- 未执行自动化测试（前端路由逻辑调整）

------
https://chatgpt.com/codex/tasks/task_e_68dcfab2c3308333add8af07bc033d06