### PR TITLE
feat: 自定义标题搜索功能

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -73,31 +73,76 @@ html, body{
   background: color-mix(in oklab, var(--c-brand) 18%, var(--c-card));
   color: var(--c-text);
 }
-.sidebar .search{
+.title-search{
+  padding: 16px 18px 12px;
   border-bottom: 1px solid var(--c-divider);
 }
-.sidebar .search .input-wrap{
-  background: color-mix(in oklab, var(--c-bg) 88%, transparent);
+.title-search__input{
+  width: 100%;
+  padding: 10px 14px;
   border-radius: 999px;
   border: 1px solid color-mix(in oklab, var(--c-muted) 22%, transparent);
-}
-.sidebar .search input{
-  background: transparent;
+  background: color-mix(in oklab, var(--c-bg) 88%, transparent);
   color: var(--c-text);
+  transition: border-color .2s ease, box-shadow .2s ease;
 }
-.sidebar .search input::placeholder{
+.title-search__input:focus{
+  outline: none;
+  border-color: color-mix(in oklab, var(--c-brand) 40%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--c-brand) 15%, transparent);
+}
+.title-search__input::placeholder{
   color: var(--c-muted);
 }
-.sidebar .search .results-panel{
+.title-search__results{
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
   background: var(--c-card);
+  border-radius: 16px;
   border: 1px solid color-mix(in oklab, var(--c-muted) 18%, transparent);
   box-shadow: var(--shadow);
+  display: none;
 }
-.sidebar .search .results-panel a{
-  color: var(--c-text);
+.title-search__results.is-open{
+  display: block;
 }
-.sidebar .search .results-panel p{
+.title-search__item{
+  padding: 10px 14px;
+  border-bottom: 1px solid color-mix(in oklab, var(--c-muted) 15%, transparent);
+}
+.title-search__item:last-child{
+  border-bottom: none;
+}
+.title-search__item--empty{
   color: var(--c-muted);
+  text-align: center;
+}
+.title-search__link{
+  display: block;
+  font-weight: 600;
+  color: var(--c-text);
+  margin-bottom: 4px;
+}
+.title-search__link:hover{
+  color: var(--c-brand);
+}
+.title-search__meta{
+  display: block;
+  font-size: 13px;
+  color: var(--c-muted);
+}
+.title-search__results::-webkit-scrollbar{
+  width: 6px;
+}
+.title-search__results::-webkit-scrollbar-thumb{
+  background: color-mix(in oklab, var(--c-muted) 25%, transparent);
+  border-radius: 999px;
+}
+.title-search__results::-webkit-scrollbar-track{
+  background: transparent;
 }
 .sidebar-toggle{
   background: var(--c-sidebar);

--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -1,0 +1,357 @@
+(function () {
+  "use strict";
+
+  const headingIndex = new Map();
+  let searchElements = null;
+  let indexPromise = null;
+  let indexReady = false;
+  let latestVM = null;
+
+  function registerPlugin() {
+    window.$docsify = window.$docsify || {};
+    const originalPlugins = window.$docsify.plugins || [];
+    window.$docsify.plugins = [].concat(titleSearchPlugin, originalPlugins);
+  }
+
+  function titleSearchPlugin(hook, vm) {
+    latestVM = vm;
+
+    hook.ready(function () {
+      ensureIndex(vm);
+    });
+
+    hook.afterEach(function (html, next) {
+      const path = normalizePath(vm.route.path || "");
+      headingIndex.set(path, extractHeadingsFromHtml(html));
+      next(html);
+    });
+
+    hook.mounted(function () {
+      ensureSearchElements();
+    });
+
+    hook.doneEach(function () {
+      if (searchElements) {
+        searchElements.results.classList.remove("is-open");
+      }
+    });
+  }
+
+  function ensureIndex(vm) {
+    if (!indexPromise) {
+      indexPromise = buildIndex(vm).finally(function () {
+        indexReady = true;
+      });
+    }
+    return indexPromise;
+  }
+
+  async function buildIndex(vm) {
+    const base = resolveBasePath(vm);
+    const paths = new Set();
+
+    const homepage = normalizePath(vm.config.homepage || "");
+    if (homepage) {
+      paths.add(homepage);
+    }
+
+    const sidebarFile = resolveSidebarFile(vm.config.loadSidebar);
+    if (sidebarFile) {
+      try {
+        const sidebarText = await fetchText(joinUrl(base, sidebarFile));
+        parseSidebarLinks(sidebarText, paths);
+      } catch (error) {
+        console.warn("[title-search] 无法加载侧边栏", error);
+      }
+    }
+
+    const tasks = Array.from(paths).map(async (path) => {
+      try {
+        const markdown = await fetchText(joinUrl(base, path));
+        headingIndex.set(path, extractHeadingsFromMarkdown(markdown));
+      } catch (error) {
+        console.warn(`[title-search] 无法索引 ${path}`, error);
+      }
+    });
+
+    await Promise.all(tasks);
+  }
+
+  function ensureSearchElements() {
+    if (searchElements && searchElements.input.isConnected) {
+      return;
+    }
+
+    const sidebar = document.querySelector(".sidebar");
+    if (!sidebar) return;
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "title-search";
+
+    const input = document.createElement("input");
+    input.type = "search";
+    input.className = "title-search__input";
+    input.placeholder = "搜索标题…";
+
+    const results = document.createElement("ul");
+    results.className = "title-search__results";
+
+    wrapper.appendChild(input);
+    wrapper.appendChild(results);
+
+    sidebar.insertBefore(wrapper, sidebar.firstChild);
+
+    input.addEventListener("focus", () => {
+      ensureIndex(latestVM || {});
+      if (input.value.trim()) {
+        results.classList.add("is-open");
+      }
+    });
+
+    input.addEventListener("input", () => {
+      renderResults(input.value.trim());
+    });
+
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        input.value = "";
+        clearResults();
+        input.blur();
+      }
+    });
+
+    document.addEventListener("click", (event) => {
+      if (!wrapper.contains(event.target)) {
+        results.classList.remove("is-open");
+      }
+    });
+
+    searchElements = { wrapper, input, results };
+  }
+
+  function renderResults(keyword) {
+    if (!searchElements) return;
+    const { results } = searchElements;
+    results.innerHTML = "";
+
+    if (!keyword) {
+      results.classList.remove("is-open");
+      return;
+    }
+
+    const normalized = keyword.toLowerCase();
+
+    if (!indexReady) {
+      const loadingItem = document.createElement("li");
+      loadingItem.className = "title-search__item title-search__item--empty";
+      loadingItem.textContent = "正在构建索引…";
+      results.appendChild(loadingItem);
+      results.classList.add("is-open");
+      ensureIndex(latestVM || {});
+      indexPromise.finally(() => {
+        if (
+          searchElements &&
+          searchElements.input.value.trim().toLowerCase() === normalized
+        ) {
+          renderResults(searchElements.input.value.trim());
+        }
+      });
+      return;
+    }
+
+    const matches = collectMatches(normalized);
+
+    if (!matches.length) {
+      const emptyItem = document.createElement("li");
+      emptyItem.className = "title-search__item title-search__item--empty";
+      emptyItem.textContent = "没有找到匹配的标题";
+      results.appendChild(emptyItem);
+      results.classList.add("is-open");
+      return;
+    }
+
+    matches.forEach((item) => {
+      const element = document.createElement("li");
+      element.className = "title-search__item";
+
+      const link = document.createElement("a");
+      link.className = "title-search__link";
+      link.href = toHash(item.path, item.id);
+      link.textContent = item.text;
+      link.addEventListener("click", () => {
+        results.classList.remove("is-open");
+        if (searchElements) {
+          searchElements.input.blur();
+        }
+      });
+
+      const meta = document.createElement("span");
+      meta.className = "title-search__meta";
+      meta.textContent = item.pageTitle || item.path;
+
+      element.appendChild(link);
+      element.appendChild(meta);
+      results.appendChild(element);
+    });
+
+    results.classList.add("is-open");
+  }
+
+  function clearResults() {
+    if (!searchElements) return;
+    searchElements.results.innerHTML = "";
+    searchElements.results.classList.remove("is-open");
+  }
+
+  function collectMatches(keyword) {
+    const results = [];
+
+    headingIndex.forEach((entry, path) => {
+      if (!entry) return;
+      const { pageTitle, headings } = entry;
+      headings.forEach((heading) => {
+        if (!heading.text) return;
+        if (heading.text.toLowerCase().includes(keyword)) {
+          results.push({
+            path,
+            id: heading.id,
+            text: heading.text,
+            pageTitle,
+          });
+        }
+      });
+    });
+
+    results.sort((a, b) => a.text.localeCompare(b.text, "zh-Hans-CN"));
+
+    return results.slice(0, 50);
+  }
+
+  function extractHeadingsFromHtml(html) {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const nodes = Array.from(
+      container.querySelectorAll("h1, h2, h3, h4, h5, h6")
+    );
+
+    if (!nodes.length) {
+      return { pageTitle: "", headings: [] };
+    }
+
+    const headings = nodes.map((node) => ({
+      text: node.textContent.trim(),
+      id: node.id || "",
+      level: Number(node.tagName.slice(1)),
+    }));
+
+    const primary = headings.find((item) => item.level === 1);
+    const pageTitle = primary ? primary.text : headings[0].text;
+
+    return { pageTitle, headings };
+  }
+
+  function extractHeadingsFromMarkdown(markdown) {
+    const lines = markdown.split(/\r?\n/);
+    const headings = [];
+    let pageTitle = "";
+
+    lines.forEach((line) => {
+      const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
+      if (!match) return;
+      const level = match[1].length;
+      const text = match[2].trim();
+      if (!text) return;
+      const id = slugify(text);
+      headings.push({ text, id, level });
+      if (!pageTitle && level === 1) {
+        pageTitle = text;
+      }
+    });
+
+    if (!pageTitle && headings.length) {
+      pageTitle = headings[0].text;
+    }
+
+    return { pageTitle, headings };
+  }
+
+  function parseSidebarLinks(markdown, paths) {
+    const pattern = /\[[^\]]+\]\(([^)]+)\)/g;
+    let match;
+    while ((match = pattern.exec(markdown))) {
+      const raw = match[1].trim();
+      if (!raw) continue;
+      if (/^(https?:)?\/\//i.test(raw)) continue;
+      if (raw.startsWith("mailto:")) continue;
+      const clean = normalizePath(raw);
+      if (!clean) continue;
+      if (!/\.md$/i.test(clean)) continue;
+      paths.add(clean);
+    }
+  }
+
+  async function fetchText(url) {
+    const response = await fetch(url, { cache: "force-cache" });
+    if (!response.ok) {
+      throw new Error(`请求失败：${response.status}`);
+    }
+    return response.text();
+  }
+
+  function resolveBasePath(vm) {
+    const base = vm && vm.config && typeof vm.config.basePath === "string"
+      ? vm.config.basePath
+      : "";
+    if (!base) return "";
+    return base.endsWith("/") ? base : `${base}/`;
+  }
+
+  function resolveSidebarFile(option) {
+    if (!option) return null;
+    if (typeof option === "string") return option;
+    return "_sidebar.md";
+  }
+
+  function joinUrl(base, path) {
+    if (/^(https?:)?\/\//i.test(path)) return path;
+    const sanitized = path.replace(/^\/*/, "");
+    if (!base) return sanitized;
+    return `${base.replace(/\/?$/, "/")}${sanitized}`;
+  }
+
+  function normalizePath(rawPath) {
+    if (!rawPath) return "";
+    const [pathPart] = rawPath.split(/[?#]/);
+    const segments = pathPart.split("/");
+    const stack = [];
+    segments.forEach((segment) => {
+      if (!segment || segment === ".") return;
+      if (segment === "..") {
+        if (stack.length) stack.pop();
+        return;
+      }
+      stack.push(segment);
+    });
+    return stack.join("/");
+  }
+
+  function slugify(text) {
+    if (window.Docsify && typeof window.Docsify.slugify === "function") {
+      return window.Docsify.slugify(text);
+    }
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\u4e00-\u9fa5\s-]/g, "")
+      .replace(/\s+/g, "-");
+  }
+
+  function toHash(path, id) {
+    const cleanPath = normalizePath(path).replace(/\.md$/i, "");
+    const base = cleanPath ? `#/${cleanPath}` : "#/";
+    if (!id) return base;
+    return `${base}?id=${encodeURIComponent(id)}`;
+  }
+
+  registerPlugin();
+})();

--- a/index.html
+++ b/index.html
@@ -183,14 +183,6 @@
           onlyCover: false,
           homepage: "README_wiki.md",
 
-          // 搜索
-          search: {
-            paths: "auto",
-            placeholder: "搜索文档…",
-            noData: "没有找到结果",
-            depth: 4,
-          },
-
           // 自定义 404 页面
           notFoundPage: "_404.md",
 
@@ -229,11 +221,13 @@
       })();
     </script>
 
+    <!-- 自定义标题搜索（需在 Docsify 启动前注册插件） -->
+    <script src="./assets/title-search.js"></script>
+
     <!-- Docsify 核心 -->
     <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
 
-    <!-- 插件：搜索 / 复制代码 / 图片缩放 / 分页 / emoji -->
-    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+    <!-- 插件：复制代码 / 图片缩放 / 分页 / emoji -->
     <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>


### PR DESCRIPTION
## 动机
- 现有搜索会匹配正文，不符合“只搜索标题”的体验需求。

## 主要变更
- 新增 `assets/title-search.js`，实现基于 Docsify 的标题专用搜索插件并自动索引侧边栏列出的词条。
- 调整 `index.html`，移除官方搜索插件，改为加载自定义标题搜索脚本。
- 更新 `assets/custom.css`，替换搜索框样式以配合新的标题搜索结果列表。

## 潜在风险
- 索引构建依赖 `_sidebar.md` 中列出的 Markdown 路径，若目录缺失可能导致词条未被纳入搜索。
- 首次加载索引需异步请求 Markdown 文件，初次搜索时会短暂显示加载提示。

## 相关条目或链接
- 无

------
https://chatgpt.com/codex/tasks/task_e_68dd0654af1083338b2caae5db828d03