### PR TITLE
修正相对 Markdown 链接的跳转逻辑

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,18 +125,7 @@
             .split("/")
             .filter((segment) => segment.length);
 
-          const normalizedWorkingPath = workingPath.replace(/^\.\//, "");
-          const isSingleMarkdownSegment =
-            !isAbsolutePath &&
-            normalizedWorkingPath.length > 0 &&
-            !normalizedWorkingPath.includes("/") &&
-            /\.md$/i.test(normalizedWorkingPath);
-
-          const stack = isAbsolutePath
-            ? []
-            : isSingleMarkdownSegment
-            ? []
-            : [...currentBaseSegments];
+          const stack = isAbsolutePath ? [] : [...currentBaseSegments];
 
           for (const segment of pathSegments) {
             if (segment === ".") continue;


### PR DESCRIPTION
## 摘要
- 调整前端自定义跳转逻辑，确保处理相对 Markdown 链接时继续基于当前目录解析路径

## 测试
- 未执行自动化测试（前端逻辑改动，需通过实际预览验证）

------
https://chatgpt.com/codex/tasks/task_e_68dd1fd1250c8333b4eb05af348cafe1