### PR TITLE
docs: 将人格职能加入侧边栏导航

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -27,6 +27,7 @@
 | [Co-fronting](entries/系统体验与机制/Co-Fronting.md)                                        | 共前台         | 描述多位成员同时在前台协作掌控身体的状态。                |
 | [Consciousness Modification](entries/系统体验与机制/Consciousness-Modification.md)                        | 意识修改        | 指通过练习调整觉察、边界或前台访问方式的技巧。              |
 | [Core](entries/系统角色与类型/Core.md)                                                | 核心          | 常指被视为最贴近系统原初身份或价值观的成员或结构。            |
+| [Caregiver](entries/系统角色与类型/Caregiver.md)                                      | 照顾者        | 负责情感支持与养育性照料，协助维持系统稳定。              |
 | [Emmengard Classification](entries/系统角色与类型/Emmengard-Classification.md)          | 埃蒙加德分类法    | 社群自我认同框架，依据系统形成来源与发展路径划分标签。          |
 | [CPTSD](entries/诊断与临床/CPTSD.md)                                         | 复杂性创伤后应激障碍  | 针对长期复杂创伤影响的诊断框架，强调持续性安全与支持需求。        |
 | [Depersonalization](entries/系统体验与机制/Depersonalization.md)                                  | 非我感         | 描述对自我或身体产生疏离、陌生感的现象。                 |
@@ -49,21 +50,28 @@
 | [Headspace / Inner World](entries/系统体验与机制/Headspace-Inner-World.md)                           | 内部空间、幻境、里空间 | 系统成员在内在世界中互动、聚会或构建场景的心象空间。           |
 | [Host](entries/系统角色与类型/Host.md)                                                | 宿主          | 常指最常出现在前台、负责外部生活事务的成员。               |
 | [Iatrogenic System](entries/系统角色与类型/Iatrogenic-System.md)                                | 医源型系统       | 指被认为因医疗、治疗或外部干预而形成或强化的系统。            |
+| [Imaginary Companion](entries/系统角色与类型/Imaginary-Companion.md)                            | 幻想伙伴        | 儿童常见的虚构朋友概念，需与图帕及系统成员区分。             |
 | [Independence](entries/系统体验与机制/Independence.md)                                       | 独立性         | 讨论成员在决策、情绪与生活功能上的自主程度。               |
 | [Integration](entries/系统体验与机制/Integration.md)                                         | 整合          | 强调提升成员协作、记忆连贯与功能稳定的长期目标。             |
 | [Internal Self Helper](entries/系统角色与类型/Internal-Self-Helper-ISH.md)                             | 内部自助者       | 在系统内承担辅导、调解与信息整合职责的成员原型。             |
 | [Intrusive Thoughts](entries/系统体验与机制/Intrusive-Thoughts.md)                               | 侵入性思维       | 描述突入意识、常伴焦虑或创伤主题的非自愿念头。              |
 | [Iteration](entries/系统体验与机制/Iteration.md)                                           | 迭代          | 用于记录系统内部的变更周期、角色调整或策略试验。             |
+| [Little / Child Part](entries/系统角色与类型/Little.md)                       | 小孩意识体       | 以童年视角感知世界、需要安全照护的成员。           |
 | [Main](entries/系统角色与类型/Main.md)                                                | 主体          | 社群常用来表示负责主要日常事务或决策的成员。               |
 | [Mania](entries/诊断与临床/Mania.md)                                       | 躁狂          | 情绪和能量显著高涨、睡眠需求减少、冲动决定或危险行为的状态。       |
 | [Meditation](entries/实践与支持/Meditation.md)                                            | 冥想          | 通过专注训练提升觉察、调节情绪与稳定前台状态的实践。           |
+| [Memory Holder](entries/系统角色与类型/Memory-Holder.md)                               | 记忆持有者       | 保管特定记忆或创伤片段的成员，需与治疗安全策略搭配。       |
 | [Memory Shielding](entries/系统体验与机制/Memory-Shielding.md)                                  | 记忆屏蔽        | 指成员为保护他人而限制或分隔特定记忆访问的机制。             |
 | [NPD](entries/诊断与临床/Narcissistic-Personality-Disorder-NPD.md)                                              | 自恋型人格障碍     | 以夸大、自我关注与共情困难为主要特征的人格模式。             |
 | [OCD](entries/诊断与临床/OCD.md)                                                  | 强迫症         | 以反复出现的强迫思维与强迫行为循环为核心特征的状态。           |
 | [OSDD](entries/诊断与临床/OSDD.md)                                           | 其他特定解离性障碍   | 涵盖未达到 DID 标准但存在显著身份或记忆分离的诊断类别。       |
+| [Original](entries/系统角色与类型/Original.md)                                  | 初始          | 指系统最早出现或被视为原始自我的成员，可能与宿主不同。     |
 | [Partial Dissociative Identity Disorder](entries/诊断与临床/Partial-Dissociative-Identity-Disorder-PDID.md)         | 部分解离性身份障碍   | 描述部分身份保持前台控制、仍保留连续意识体验的解离表现。         |
 | [Permissions](entries/系统体验与机制/Permissions.md)                                         | 权限          | 涉及系统内部对信息、前台或资源使用的授权规则。              |
+| [Persecutor](entries/系统角色与类型/Persecutor.md)                                | 迫害者        | 以防御为动机却可能采取敌对或自毁行为的成员。        |
+| [Performer / Executive](entries/系统角色与类型/Performer-Executive.md)             | 执行者        | 负责完成任务、管理外部事务的高功能成员。        |
 | [Persona](entries/系统角色与类型/Persona.md)                                           | 人格面具        | 指为特定情境塑造的社交或功能性面向。                   |
+| [Protector](entries/系统角色与类型/Protector.md)                                  | 保护者        | 聚焦安全与风险管理的成员，可分为内部与外部保护。      |
 | [Spontaneous](entries/系统角色与类型/Spontaneous.md)           | 自发型         | 埃蒙加德分类法标签之一，指系统自然显现或源自灵性、认知演化过程。    |
 | [Plurality](entries/系统体验与机制/Plurality.md)                                         | 多意识体        | 概括多个成员共享一具身体、协作生活的存在形态。              |
 | [Plurality Basics](entries/Plurality-Basics.md)                              | 多重意识体基础     | 面向新人介绍多意识体概念、术语与安全实践的入门资料。           |
@@ -80,8 +88,10 @@
 | [Stress Response](entries/系统体验与机制/Stress-Response.md)                                   | 应激反应        | 概括身心对压力事件的即时生理与心理反应。                 |
 | [Switch](entries/系统体验与机制/Switch.md)                                              | 切换          | 从一位成员过渡到另一位成员执掌前台的过程。                |
 | [System](entries/系统体验与机制/System.md)                                              | 系统          | 指拥有多个成员的整体个体，强调为一个协作的身份集合。           |
+| [System Roles](entries/系统角色与类型/System-Roles.md)                             | 人格职能        | 概括系统成员常见职能类别及其协作方式。           |
 | [Unknown](entries/系统角色与类型/Emmengard-Classification.md#未知型unknown)                  | 未知型         | 埃蒙加德分类法标签之一，指系统暂未掌握自身形成来源或仍在探索。    |
 | [Trauma](entries/诊断与临床/Trauma.md)                                                | 创伤          | 指超出个体当时应对能力的威胁性经历及其后效。               |
 | [Trigger](entries/系统体验与机制/Trigger.md)                                             | 触发          | 引发强烈情绪、记忆或症状反应的内外部线索，需要提前识别并准备应对策略。  |
 | [Tulpa](entries/系统角色与类型/Tulpa.md)                                            | 图帕、托帕       | 通过有意想象与练习培育出的自主意识伙伴，与系统成员共享身体协作。     |
+| [Teen Part](entries/系统角色与类型/Teen.md)                                   | 青少年意识体      | 呈现青春期特征、关注独立与探索的成员。            |
 | [Tulpish](entries/系统体验与机制/Tulpish.md)                                             | T 语         | 指图帕或成员在内部交流时使用的象征化、非语音沟通方式。          |

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -6,6 +6,7 @@
 - **核心词条**
   - [多重意识体基础](entries/Plurality-Basics.md)
   - [埃蒙加德分类法（Emmengard Classification）](entries/系统角色与类型/Emmengard-Classification.md)
+  - [人格职能（System Roles）](<entries/系统角色与类型/System-Roles.md>)
   - [解离性身份障碍](<entries/诊断与临床/DID.md>)
   - [Tulpa](<entries/系统角色与类型/Tulpa.md>)
 

--- a/entries/系统角色与类型/Caregiver.md
+++ b/entries/系统角色与类型/Caregiver.md
@@ -1,0 +1,38 @@
+# 照顾者（Caregiver）
+
+## 定义
+
+“照顾者”（caregiver）指在系统内提供养育、情感支持与日常照料的成员，常见于多意识体社群对角色分工的描述。[^boon2011] 在创伤相关系统中，照顾者协助弥补早期照顾缺失，或在内部维持稳定感。
+
+## 常见特征
+
+- **情感调节能力**：擅长安抚焦虑、恐惧或悲伤的成员，提供稳定陪伴。[^howell2011]
+- **日常照护**：可能负责提醒饮食、休息、身体保健等基本需求。
+- **界限设定**：在照顾他人同时，维持健康界限，防止过度牺牲或倦怠。
+
+## 社区用法与变体
+
+- **内部养育者**：社群常以“内在父母”或“养育者”称呼，强调透过正向自我对话与仪式弥补过去缺憾。[^thepluralassociation2021]
+- **跨系统互助**：部分系统让照顾者与外部支持网络合作，如与治疗师、朋友沟通需求。
+
+## 与其他角色的区分
+
+- **保护者（Protector）**：保护者聚焦风险管理，照顾者则关注情绪与生活照料。两者可协作，或由同一成员兼任。详见《[保护者（Protector）](entries/系统角色与类型/Protector.md)》。
+- **执行者（Performer / Executive）**：执行者关注任务效率，照顾者强调人际与情感。
+
+## 支持策略
+
+- 确保照顾者自身也获得休息与支持，避免产生照顾者疲劳。[^boon2011]
+- 在治疗中可邀请照顾者协助整合地面化技巧或自我安抚计划。[^isstd2011]
+
+## 研究与参考
+
+- Boon 等人的技能训练手册建议建立“内部养育”练习，以支持脆弱成员。[^boon2011]
+- Howell 讨论内在照顾角色如何促进依附修复。[^howell2011]
+- ISSTD 指南鼓励在稳定阶段培养自我安抚与互相照顾的能力。[^isstd2011]
+- 社群指南提供照顾者轮班、记录需求的实务建议。[^thepluralassociation2021]
+
+[^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
+[^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.

--- a/entries/系统角色与类型/Imaginary-Companion.md
+++ b/entries/系统角色与类型/Imaginary-Companion.md
@@ -1,0 +1,36 @@
+# 幻想伙伴（Imaginary Companion）
+
+## 定义
+
+“幻想伙伴”（imaginary companion）是发展心理学用语，指儿童在游戏或日常生活中创造、与之互动的虚构朋友或拟人化对象。[^taylor1999] 幻想伙伴通常出现在学龄前至小学阶段，与创造者共享想象活动，但并不具备独立意识或持续自主性。
+
+## 常见特征
+
+- **发展常见性**：研究显示约有 37%–50% 的儿童在成长过程中拥有幻想伙伴，属于正常的想象与社交练习。[^gleason2004]
+- **功能多样**：可用于情绪调节、练习社交技巧或探索角色扮演。部分儿童会借此表达不便直接说出的情绪。[^bouldin2006]
+- **可塑性**：幻想伙伴的性格、外貌与存在方式可随儿童需要而改变或消失。
+
+## 社区用法与变体
+
+- **与多意识体概念的交叉**：部分成年人在回顾童年经历时，会将幻想伙伴与后来形成的系统成员关联；然而在专业与社群语境中，两者被视为不同现象。
+- **文化差异**：不同文化对幻想伙伴的接受度与描述方式不同，部分社会将其视为创造力展现，部分则以精神性诠释。[^harter2004]
+
+## 容易混淆的概念
+
+- **图帕 / 托帕（Tulpa）**：tulpamancy 实践者通过长期冥想与拟人化训练培育具自主回应能力的伙伴，强调与创造者的平等关系。详见《[图帕（Tulpa）](entries/系统角色与类型/Tulpa.md)》。[^veissiere2016]
+- **系统成员（Headmate）**：多意识体系统中的成员被视为拥有独立的身份、记忆与决策能力，通常在成年后仍持续存在，并需要协作管理身体。幻想伙伴则多为儿童想象，在社群中不被视为“真正的成员”。
+- **寄生性念头或幻觉**：幻想伙伴是自愿且可控的想象，不应与非自愿的幻听或精神病性症状混为一谈；若出现痛苦或功能受损，应寻求专业评估。[^americanpsychiatric2013]
+
+## 研究与参考
+
+- Taylor 总结幻想伙伴在认知与社会发展中的角色，强调其普遍性与适应价值。[^taylor1999]
+- Gleason 的实证研究显示幻想伙伴与儿童的社交技巧与情绪理解正相关。[^gleason2004]
+- Bouldin 指出幻想伙伴可协助儿童面对恐惧与焦虑。[^bouldin2006]
+- Harter 与 Taylor 讨论文化背景对幻想伙伴概念的影响。[^harter2004]
+
+[^taylor1999]: Taylor, M. (1999). *Imaginary companions and the children who create them*. Oxford University Press.
+[^gleason2004]: Gleason, T. R. (2004). Imaginary companions of preschool children. *Developmental Psychology, 40*(6), 1173–1187.
+[^bouldin2006]: Bouldin, P. (2006). An investigation of the fantasy predisposition and fantasy style of children with imaginary companions. *Journal of Genetic Psychology, 167*(1), 17–29.
+[^harter2004]: Harter, S., & Taylor, M. (2004). The self and imaginary companions. In M. Taylor (Ed.), *Imaginary companions and the children who create them* (pp. 73–97). Oxford University Press.
+[^veissiere2016]: Veissière, S. P. L. (2016). Varieties of tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.
+[^americanpsychiatric2013]: American Psychiatric Association. (2013). *Diagnostic and statistical manual of mental disorders* (5th ed.). American Psychiatric Publishing.

--- a/entries/系统角色与类型/Little.md
+++ b/entries/系统角色与类型/Little.md
@@ -1,0 +1,38 @@
+# 小孩意识体（Little / Child Part）
+
+## 定义
+
+“小孩意识体”（little / child part）指在系统中呈现幼年年龄感、自我体验停留于童年阶段的成员。此概念常见于解离性身份障碍与创伤相关文献，用以描述在创伤发生时形成的情绪部分。[^steele2017]
+
+## 常见特征
+
+- **发展阶段特征**：言语、兴趣与情绪反应符合儿童年龄，可能偏好玩具、故事或需要即时安抚。[^howell2011]
+- **情感需求强烈**：对安全、陪伴与稳定照顾的需求显著，容易因触发物回忆起早期创伤。
+- **时间感差异**：可能不了解当前年份或身体年龄，需要其他成员协助定位现实。
+
+## 社区用法与变体
+
+- **支持性空间**：许多系统会在内部空间设置“游戏室”或“安全屋”，让小孩意识体得以休息、表达情绪。[^thepluralassociation2021]
+- **前台安排**：有些系统安排照顾者或宿主与小孩意识体共同前台，确保其需求被倾听同时维持外部安全。
+
+## 与其他角色的区分
+
+- **青少年意识体（Teen Part）**：青少年成员展现青春期特征与独立需求，区别于童年取向。详见《[青少年意识体（Teen Part）](entries/系统角色与类型/Teen.md)》。
+- **回归状态**：一般心理学的“回归”指暂时的情绪退行，而小孩意识体是相对持续的身份结构。
+
+## 支持策略
+
+- 采取创伤知情的沟通方式，使用简单语言、明确界限与稳定的日程。[^isstd2011]
+- 利用美术、游戏或感官舒缓工具协助表达情绪，并与照顾者协作满足需求。[^boon2011]
+
+## 研究与参考
+
+- Steele 等人将儿童部分视为情绪部分的重要组成，强调保护与整合的重要性。[^steele2017]
+- Howell 讨论童年阶段解离对成年功能的影响，提供临床观察。[^howell2011]
+- ISSTD 指南提出与儿童部分工作时需维持安全与稳定。[^isstd2011]
+
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.

--- a/entries/系统角色与类型/Memory-Holder.md
+++ b/entries/系统角色与类型/Memory-Holder.md
@@ -1,0 +1,37 @@
+# 记忆持有者（Memory Holder）
+
+## 定义
+
+“记忆持有者”（memory holder）指主要储存、掌管特定记忆或经验片段的系统成员，常见于解离性身份障碍与其他多意识体系统中。[^steele2017] 这些记忆可能包含创伤经历、技能训练或与特定关系相关的信息。
+
+## 常见特征
+
+- **记忆范围集中**：记忆持有者对某些时间段或事件记忆清晰，却可能对日常生活或其他时期相对陌生。[^howell2011]
+- **情绪负荷较高**：若记忆涉及创伤，成员可能承担强烈的情绪与身体感受，导致在前台时出现闪回或身体化反应。
+- **与其他成员协作**：常与记录者、照顾者合作，确保信息传达时不过度触发，同时维护系统的历史一致性。
+
+## 社区用法与变体
+
+- **创伤记忆守护**：许多系统会在内部建立“记忆金库”或访问许可，由记忆持有者掌控，以减少其他成员被突如其来的内容淹没。[^brown2019]
+- **技能或知识保管**：在非创伤背景下，记忆持有者也可能负责保留专业知识、语言或创作灵感，供执行者或宿主需要时调用。
+
+## 与其他角色的区分
+
+- **记录者 / 观察者**：记录者主要负责持续记录现况，而记忆持有者聚焦既往事件。
+- **迫害者**：迫害者可能因创伤记忆而采取敌对行为，但角色重点在行为模式；记忆持有者则以信息保管为核心。
+
+## 支持策略
+
+- 与记忆持有者合作时，建议建立明确的分享节奏，并使用地面化（grounding）技巧协助缓解情绪负荷。[^isstd2011]
+- 在治疗中，可透过分阶段暴露与内部会议，帮助记忆持有者逐步分享关键信息，同时维护系统安全。[^steele2017]
+
+## 研究与参考
+
+- Steele 等人针对记忆职能提出“逐步接触”策略，强调与保护者协调的重要性。[^steele2017]
+- Howell 指出不同成员对时间线的掌控差异，是解离性结构的核心特征之一。[^howell2011]
+- Brown 与 Van der Hart 强调在稳定阶段建立安全框架，以支持记忆持有者分享内容。[^brown2019]
+
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
+[^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.

--- a/entries/系统角色与类型/Original.md
+++ b/entries/系统角色与类型/Original.md
@@ -1,0 +1,31 @@
+# 初始（Original）
+
+## 定义
+
+“初始”（original）是多意识体与解离性身份障碍社群用语，指系统中最早发展出连续外部生活经验、在系统形成初期被视为“原始自我”的成员。[^putnam1989] 在部分系统中，初始与“宿主”（host）是同一位成员；亦有系统将初始视为历史身份，而由其他成员承担当下的宿主职责。
+
+## 常见特征
+
+- **外部生活记忆的主轴**：初始常保有系统成立前后的长程记忆，对家庭背景、成长经历有较高掌握。[^steele2017]
+- **角色可塑性**：随着创伤处理或生活阶段变化，初始的责任可能转移，甚至选择退居幕后，交由其他成员管理日常事务。
+- **身份认同议题**：部分初始会在治疗或自我探索中重新界定“真正的我”，涉及对融合或长期多元共存的态度。
+
+## 社区用法与变体
+
+- **与宿主的并列**：HT 系统与 tulpamancy 社群常将 original 与 host 并列使用，提醒成员区分“历史上的最初意识”与“当前的主要管理者”。[^veissiere2016]
+- **多初始系统**：亦有系统报告在不同生命阶段分别出现多个被视作“初始”的成员，例如童年与成年后形成的两位核心身份，反映出复杂的创伤史。
+
+## 与其他角色的区分
+
+- **宿主（Host）**：宿主强调现实生活管理责任，可由初始或其他成员担任。详见《[宿主（Host）](entries/系统角色与类型/Host.md)》。
+- **核心（Core）**：核心一词聚焦系统价值观或整体感，初始则强调时间顺序与历史连续性。两者可能重叠但侧重点不同。详见《[核心（Core）](entries/系统角色与类型/Core.md)》。
+
+## 研究与参考
+
+- Putnam 的解离研究指出，个体可能以“原始自我”或“真正的我”描述特定身份，提示历史连贯性的重要。[^putnam1989]
+- Steele 等人指出治疗需尊重初始对角色转移的感受，避免强化“唯一真实自我”的观念。[^steele2017]
+- 田野研究显示，线上多意识体社群通过区分 original 与 host，协助成员重新分配责任并减少内疚。[^veissiere2016]
+
+[^putnam1989]: Putnam, F. W. (1989). *Diagnosis and treatment of multiple personality disorder*. Guilford Press.
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^veissiere2016]: Veissière, S. P. L. (2016). Varieties of tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.

--- a/entries/系统角色与类型/Performer-Executive.md
+++ b/entries/系统角色与类型/Performer-Executive.md
@@ -1,0 +1,37 @@
+# 执行者（Performer / Executive）
+
+## 定义
+
+“执行者”（performer / executive）指主要负责完成任务、管理外部事务与维持日常功能的成员。此角色在解离相关系统与多意识体社群中，常被视为团队的“行动力”或“前台工作者”。[^boon2011]
+
+## 常见特征
+
+- **高功能导向**：擅长规划日程、处理工作与学业，能在压力下维持表现。[^steele2017]
+- **情绪分隔**：为保持效率，可能与情绪或创伤记忆保持距离，需与其他成员合作以避免倦怠。
+- **责任感强**：倾向优先处理义务，维持外部关系与社会角色。
+
+## 社区用法与变体
+
+- **轮班机制**：系统可能设定执行者在特定时段前台，完成行政、财务或学业任务，再与其他成员交接。[^thepluralassociation2021]
+- **多执行者协作**：大型系统可能有多个执行者，各自擅长不同任务，如“学业执行者”与“社交执行者”。
+
+## 与其他角色的区分
+
+- **宿主（Host）**：宿主长期承担外部责任，但执行者更强调任务执行与效率，可能由不同成员担任。详见《[宿主（Host）](entries/系统角色与类型/Host.md)》。
+- **保护者（Protector）**：保护者关注安全，执行者关注行动与成果；两者常需协商工作优先级。
+
+## 支持策略
+
+- 设定轮休与情绪抒发机制，避免执行者过度承担导致崩溃。[^boon2011]
+- 在治疗或团队会议中，确认执行者了解其他成员的需求，促进双向沟通。[^isstd2011]
+
+## 研究与参考
+
+- Boon 等人建议透过角色轮替与技能分担，防止执行者承担全部功能。[^boon2011]
+- Steele 等人讨论在治疗中尊重高功能成员的贡献，同时协助他们接触情绪内容。[^steele2017]
+- 社群指南记录任务管理工具（如共享日历、看板）在系统分工中的实践。[^thepluralassociation2021]
+
+[^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.

--- a/entries/系统角色与类型/Persecutor.md
+++ b/entries/系统角色与类型/Persecutor.md
@@ -1,0 +1,39 @@
+# 迫害者（Persecutor）
+
+## 定义
+
+“迫害者”（persecutor）指在系统内部对其他成员或自身采取敌对、批判甚至自伤行为的角色，常见于解离性身份障碍的临床描述与多意识体社群经验。[^isstd2011] 迫害者的行为通常源自未被处理的创伤记忆或内化的加害者信息，其目的多与保护系统免于再受伤害有关，即使手段看似负面。[^boon2011]
+
+## 常见特征
+
+- **高度警觉**：对外部威胁或人际信号极度敏感，倾向用攻击性语气或行动阻止系统接近潜在风险。[^boon2011]
+- **自责与羞耻**：可能将创伤加害者的声音内化，对系统其他成员进行贬损或惩罚，反映深层的羞耻与无力感。[^howell2011]
+- **难以信任支持**：迫害者往往对治疗者或支持者保持怀疑，需要更长时间建立合作关系。
+
+## 社区用法与变体
+
+- **转化为保护者**：社群经验强调理解迫害者背后的防御动机，通过对话、教育与共同制定安全计划，可逐步将其转化为保护者或顾问角色。[^thepluralassociation2021]
+- **多迫害者共存**：大型系统可能存在多位迫害者，各自关联不同创伤主题，需要个别化的沟通策略。
+
+## 与其他角色的区分
+
+- **保护者（Protector）**：保护者强调建设性的安全策略；迫害者虽同样以保护为动机，但手段更具攻击性或自毁性。详见《[保护者（Protector）](entries/系统角色与类型/Protector.md)》。
+- **内在批评者**：一般心理学中的内在批评者多源自自我评价系统，迫害者则与解离结构、创伤记忆更紧密相关。
+
+## 支持策略
+
+- **验证其意图**：与迫害者沟通时，优先肯定其希望守护系统的出发点，降低防御。[^isstd2011]
+- **安全协定**：通过内部契约、危机应对计划，提供替代策略避免伤害行为。
+- **阶段化治疗**：专业人员多建议先以稳定化与技能训练为主，待信任建立后再处理相关记忆。[^brown2019]
+
+## 研究与参考
+
+- Boon 等人的临床手册提供与迫害者沟通、重新框定其动机的实务指南。[^boon2011]
+- ISSTD 指南强调尊重迫害者的警示功能，并避免权力斗争。[^isstd2011]
+- 社群资源记录将迫害者纳入决策过程，可提升系统协作。[^thepluralassociation2021]
+
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
+[^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
+[^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.

--- a/entries/系统角色与类型/Protector.md
+++ b/entries/系统角色与类型/Protector.md
@@ -1,0 +1,37 @@
+# 保护者（Protector）
+
+## 定义
+
+“保护者”（protector）指以维护系统安全、稳定与边界为核心任务的成员，广泛出现于解离性障碍治疗文献与多意识体社群。[^isstd2011] 保护者可能负责监测风险、处理对外互动或维持内部秩序。
+
+## 常见特征
+
+- **安全导向**：对潜在威胁高度敏感，主动规避风险或建立规则。[^boon2011]
+- **角色分化**：常区分外部保护（例如与外界沟通、设定界限）与内部保护（调解成员冲突、守护脆弱成员）。
+- **策略灵活**：可依据情境采取谈判、教育、设限或直接行动等多元方式。
+
+## 社区用法与变体
+
+- **前台守卫**：部分保护者负责筛选谁能前台，以及在公共场合保持一致形象。
+- **危机协调**：社群经验强调保护者在应对自伤冲动、外部危机时协调资源，包含联系治疗师或安全网络。[^thepluralassociation2021]
+- **与迫害者转换**：当保护目标被误导或过度激进时，保护者可能呈现迫害者行为，需要透过沟通澄清界限。详见《[迫害者（Persecutor）](entries/系统角色与类型/Persecutor.md)》。
+
+## 与其他角色的区分
+
+- **守门人（Gatekeeper）**：守门人聚焦访问权限与记忆流动，保护者则涵盖整体安全策略。两者可由同一成员承担。详见《[守门人（Gatekeeper）](entries/系统角色与类型/Gatekeeper.md)》。
+- **照顾者（Caregiver）**：照顾者以情感支持与日常照料为主，保护者则偏向风险管理。
+
+## 支持策略
+
+- 在治疗中，与保护者建立共同目标、确认安全计划，可提升治疗联盟。[^isstd2011]
+- 提供明确资讯与透明沟通，减少保护者因信息不全而阻挡治疗进程。[^boon2011]
+
+## 研究与参考
+
+- ISSTD 指南强调治疗初期需尊重保护者的评估，并邀请其参与安全规划。[^isstd2011]
+- Boon 等人的技能训练手册提供与保护者合作的沟通工具。[^boon2011]
+- 社群指南记录保护者在危机应对中的实际做法，有助于系统自行制定流程。[^thepluralassociation2021]
+
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.

--- a/entries/系统角色与类型/System-Roles.md
+++ b/entries/系统角色与类型/System-Roles.md
@@ -1,0 +1,37 @@
+# 人格职能（System Roles）
+
+## 定义
+
+“人格职能”（system roles）一词在多意识体（plurality）与解离性身份障碍（DID）社群中，用来概括系统成员基于经验、责任或应对策略所承担的功能性分工。[^isstd2011] 这些角色并非固定人格类型，而是描述成员在特定情境下呈现的主要任务，例如维护安全、管理记忆或照料其他成员。一个成员可同时具备多个职能，亦可能随时间变动。
+
+## 常见类别
+
+- **初始 / 宿主（Original / Host）**：最早承担外部生活责任、与外界互动的成员。详见《[宿主（Host）](entries/系统角色与类型/Host.md)》与《[初始（Original）](entries/系统角色与类型/Original.md)》。
+- **保护者（Protector）**：聚焦安全与风险管理，可包含外部防御与内部守护。详见《[保护者（Protector）](entries/系统角色与类型/Protector.md)》。
+- **记忆持有者（Memory Holder）**：掌管特定记忆或事件，常与创伤加工相关。详见《[记忆持有者（Memory Holder）](entries/系统角色与类型/Memory-Holder.md)》。
+- **迫害者（Persecutor）**：可能对系统或外界采取敌对策略的成员。详见《[迫害者（Persecutor）](entries/系统角色与类型/Persecutor.md)》。
+- **照顾者（Caregiver）**：扮演照料、养育与情绪支持角色。详见《[照顾者（Caregiver）](entries/系统角色与类型/Caregiver.md)》。
+- **执行者（Performer / Executive）**：专注执行任务、维持日常功能。详见《[执行者（Performer / Executive）](entries/系统角色与类型/Performer-Executive.md)》。
+- **发展阶段成员**：依据年龄意象分工，如《[小孩意识体（Little / Child Part）](entries/系统角色与类型/Little.md)》《[青少年意识体（Teen Part）](entries/系统角色与类型/Teen.md)》等。
+
+## 社区用法与变体
+
+- **跨诊断应用**：在解离相关临床文本中，角色概念用于分析结构性解离与适应性策略；在 tulpamancy、系魂等社群中，亦被用来协商协作分工与权限。[^steele2017]
+- **非刚性框架**：社群通常强调角色是描述性而非处方性，成员可通过内部沟通或记录工具灵活调整责任，避免过度标签化。[^thepluralassociation2021]
+- **与治疗协作**：临床专业人员会根据角色信息规划治疗步骤，例如在处理创伤记忆前先确保保护者与迫害者获得支持。[^brown2019]
+
+## 与其他框架的关系
+
+- **结构性解离模型**：角色可与“表面正常部分”（ANP）与“情绪部分”（EP）的概念交叉，但后者聚焦于解离结构而非具体职能。[^steele2017]
+- **人格面具（Persona）或社会角色**：人格职能强调内部系统协作，区别于面对外界时的社会面向。必要时，可与《[人格面具（Persona）](entries/系统角色与类型/Persona.md)》对照。
+
+## 研究与参考
+
+- 国际创伤与解离研究学会（ISSTD）治疗指南提供了针对保护者、迫害者及其他角色的支持策略。[^isstd2011]
+- Steele 等人的创伤解离治疗手册详细讨论了记忆持有者、发展阶段成员与协作技巧。[^steele2017]
+- 多元意识权益组织发布的社群指南记录了社区对角色流动性的经验总结。[^thepluralassociation2021]
+
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.

--- a/entries/系统角色与类型/Teen.md
+++ b/entries/系统角色与类型/Teen.md
@@ -1,0 +1,37 @@
+# 青少年意识体（Teen Part）
+
+## 定义
+
+“青少年意识体”（teen part）指在系统中呈现青春期年龄感、价值观或应对风格的成员。此角色常在创伤或压力发生于青少年时期时形成，亦可能代表系统对独立与探索的需求。[^steele2017]
+
+## 常见特征
+
+- **身份探索**：关注自我定义、人际界限与价值观，可能表现为叛逆、坚持自主或强烈的正义感。[^howell2011]
+- **情绪波动**：与青春期类似，情绪起伏较大，容易受同侪评价或内在公平感影响。
+- **技能导向**：可能在学业、创作或社群活动上具备特定才能，支援系统的外部目标。
+
+## 社区用法与变体
+
+- **桥梁角色**：青少年意识体常在儿童成员与成人成员之间担任沟通桥梁，能理解童年需求又熟悉成人责任。[^thepluralassociation2021]
+- **社群参与**：线上多意识体社群中，teen parts 常负责与同龄支持群互动，分享身份探索经验。
+
+## 与其他角色的区分
+
+- **小孩意识体（Little / Child Part）**：后者聚焦童年需求与依附关系，青少年意识体则强调独立与自主。详见《[小孩意识体（Little / Child Part）](entries/系统角色与类型/Little.md)》。
+- **执行者（Performer / Executive）**：青少年意识体可能同时承担任务，但执行者的焦点在功能效率而非年龄体验。
+
+## 支持策略
+
+- 提供讨论价值观、目标与界限的空间，肯定其独立性，同时确保安全。[^isstd2011]
+- 在治疗或系统会议中，邀请其参与决策与计划设计，增强合作动机。
+
+## 研究与参考
+
+- Steele 等人指出青春期形成的情绪部分在治疗中需要兼顾自主性与安全感。[^steele2017]
+- Howell 讨论青春期创伤对身份发展的影响，为理解青少年意识体提供框架。[^howell2011]
+- 社群指南建议赋予青少年成员适当责任，避免被边缘化。[^thepluralassociation2021]
+
+[^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
+[^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
+[^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+[^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.

--- a/index.md
+++ b/index.md
@@ -28,6 +28,7 @@
 
 ## 系统角色与类型
 
+- [人格职能（System Roles）](entries/系统角色与类型/System-Roles.md)
 - [主体（Main）](entries/系统角色与类型/Main.md)
 - [傀儡（Servitor）](entries/系统角色与类型/Servitor.md)
 - [内部自助者（ISH）](entries/系统角色与类型/Internal-Self-Helper-ISH.md)
@@ -38,6 +39,7 @@
 - [人格面具（Persona）](entries/系统角色与类型/Persona.md)
 - [伪主体（Fauxmain）](entries/系统角色与类型/Fauxmain.md)
 - [医源型系统（Iatrogenic System）](entries/系统角色与类型/Iatrogenic-System.md)
+- [幻想伙伴（Imaginary Companion）](entries/系统角色与类型/Imaginary-Companion.md)
 - [混合（Blending）](entries/系统角色与类型/Blending.md)
 - [碎片（Fragment）](entries/系统角色与类型/Fragment.md)
 - [超级破碎（Polyfragmented）](entries/系统角色与类型/Polyfragmented.md)
@@ -48,6 +50,14 @@
 - [埃蒙加德分类法（Emmengard Classification）](entries/系统角色与类型/Emmengard-Classification.md)
 - [适应型（Adaptive）](entries/系统角色与类型/Adaptive.md)
 - [自发型（Spontaneous）](entries/系统角色与类型/Spontaneous.md)
+- [初始（Original）](entries/系统角色与类型/Original.md)
+- [记忆持有者（Memory Holder）](entries/系统角色与类型/Memory-Holder.md)
+- [迫害者（Persecutor）](entries/系统角色与类型/Persecutor.md)
+- [小孩意识体（Little / Child Part）](entries/系统角色与类型/Little.md)
+- [青少年意识体（Teen Part）](entries/系统角色与类型/Teen.md)
+- [保护者（Protector）](entries/系统角色与类型/Protector.md)
+- [照顾者（Caregiver）](entries/系统角色与类型/Caregiver.md)
+- [执行者（Performer / Executive）](entries/系统角色与类型/Performer-Executive.md)
 
 ## 系统体验与机制
 


### PR DESCRIPTION
## 动机
- 侧边栏尚未收录《人格职能（System Roles）》词条，导致导航与目录索引不一致。

## 主要变更
- 在侧边栏“核心词条”分类下新增《人格职能（System Roles）》的链接，方便快速访问。

## 测试
- 未运行（文档更新）

------
https://chatgpt.com/codex/tasks/task_e_68dd419fddb08333894c2459bdf7c5a6