### PR TITLE
修复 Docsify 最后更新时间显示

### DIFF
--- a/assets/last-updated.js
+++ b/assets/last-updated.js
@@ -1,0 +1,143 @@
+(function () {
+  "use strict";
+
+  const cache = new Map();
+  const CLASS_NAME = "last-updated-indicator";
+
+  function registerPlugin() {
+    window.$docsify = window.$docsify || {};
+    if (!window.$docsify.formatUpdated) {
+      window.$docsify.formatUpdated = "{YYYY}-{MM}-{DD} {HH}:{mm}";
+    }
+    const originalPlugins = window.$docsify.plugins || [];
+    window.$docsify.plugins = [].concat(lastUpdatedPlugin, originalPlugins);
+  }
+
+  function lastUpdatedPlugin(hook, vm) {
+    hook.beforeEach(function (content, next) {
+      resolveLastModified(vm)
+        .then(function (date) {
+          vm.route.updated = date instanceof Date ? date : undefined;
+        })
+        .finally(function () {
+          next(content);
+        });
+    });
+
+    hook.doneEach(function () {
+      renderLastUpdated(vm);
+    });
+  }
+
+  function resolveLastModified(vm) {
+    const file = vm.route && vm.route.file ? vm.route.file : resolveDefaultFile(vm);
+    if (!file) return Promise.resolve(null);
+
+    const base = vm.config && vm.config.basePath ? vm.config.basePath : "";
+    const url = buildFileUrl(base, file);
+    if (!url) return Promise.resolve(null);
+
+    if (cache.has(url)) {
+      return cache.get(url);
+    }
+
+    const promise = fetch(url, { method: "HEAD", cache: "no-store" })
+      .then(function (response) {
+        if (!response || !response.ok) return null;
+        const header = response.headers ? response.headers.get("last-modified") : null;
+        if (!header) return null;
+        const parsed = new Date(header);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      })
+      .catch(function () {
+        return null;
+      });
+
+    cache.set(url, promise);
+    return promise;
+  }
+
+  function resolveDefaultFile(vm) {
+    const homepage = vm.config && vm.config.homepage ? vm.config.homepage : null;
+    if (homepage) return homepage;
+    return "README.md";
+  }
+
+  function buildFileUrl(basePath, filePath) {
+    if (/^[a-zA-Z]+:\/\//.test(filePath) || filePath.startsWith("//")) {
+      return filePath;
+    }
+
+    if (!basePath) {
+      return filePath;
+    }
+
+    if (/^[a-zA-Z]+:\/\//.test(basePath) || basePath.startsWith("//")) {
+      try {
+        return new URL(filePath.replace(/^\//, ""), ensureTrailingSlash(basePath)).toString();
+      } catch (error) {
+        console.warn("[last-updated] 无法解析 URL", error);
+        return filePath;
+      }
+    }
+
+    const normalizedBase = ensureTrailingSlash(basePath);
+    const normalizedFile = filePath.replace(/^\//, "");
+    return normalizedBase + normalizedFile;
+  }
+
+  function ensureTrailingSlash(input) {
+    return input.endsWith("/") ? input : input + "/";
+  }
+
+  function renderLastUpdated(vm) {
+    const container = ensureContainer();
+    if (!container) return;
+
+    const value = vm.route && vm.route.updated instanceof Date ? vm.route.updated : null;
+    const format = vm.config && vm.config.formatUpdated
+      ? vm.config.formatUpdated
+      : "{YYYY}-{MM}-{DD} {HH}:{mm}";
+
+    container.textContent = value
+      ? "最后更新：" + formatDate(value, format)
+      : "最后更新：暂无记录";
+  }
+
+  function ensureContainer() {
+    const contentRoot = document.querySelector(".content");
+    if (!contentRoot) return null;
+
+    let container = contentRoot.querySelector("." + CLASS_NAME);
+    if (!container) {
+      container = document.createElement("div");
+      container.className = CLASS_NAME;
+      container.style.cssText =
+        "color:#999;font-size:12px;text-align:right;margin-top:1.5em;";
+      contentRoot.appendChild(container);
+    }
+
+    return container;
+  }
+
+  function formatDate(date, template) {
+    const map = {
+      YYYY: date.getFullYear(),
+      MM: pad(date.getMonth() + 1),
+      DD: pad(date.getDate()),
+      HH: pad(date.getHours()),
+      mm: pad(date.getMinutes()),
+      ss: pad(date.getSeconds()),
+    };
+
+    return template.replace(/\{(YYYY|MM|DD|HH|mm|ss)\}/g, function (_, token) {
+      return map[token];
+    });
+  }
+
+  function pad(value) {
+    return String(value).padStart(2, "0");
+  }
+
+  registerPlugin();
+})();

--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -12,13 +12,6 @@
     if (!window.$docsify.formatUpdated) {
       window.$docsify.formatUpdated = "{YYYY}-{MM}-{DD} {HH}:{mm}";
     }
-    if (!window.$docsify.timeUpdater) {
-      window.$docsify.timeUpdater = {
-        text:
-          "<div align='right' style='color:#999;font-size:12px'>最后更新：{docsify-updated}</div>",
-        whereToPlace: "bottom",
-      };
-    }
     const originalPlugins = window.$docsify.plugins || [];
     window.$docsify.plugins = [].concat(titleSearchPlugin, originalPlugins);
   }

--- a/index.html
+++ b/index.html
@@ -180,11 +180,6 @@
 
           // 最后更新时间配置
           formatUpdated: "{YYYY}-{MM}-{DD} {HH}:{mm}",
-          timeUpdater: {
-            text:
-              "<div align='right' style='color:#999;font-size:12px'>最后更新：{docsify-updated}</div>",
-            whereToPlace: "bottom",
-          },
 
           // 首页直接展示 Main_Page，无需封面
           coverpage: false,
@@ -232,11 +227,11 @@
     <!-- 自定义标题搜索（需在 Docsify 启动前注册插件） -->
     <script src="./assets/title-search.js"></script>
 
+    <!-- 本地最后更新时间插件 -->
+    <script src="./assets/last-updated.js"></script>
+
     <!-- Docsify 核心 -->
     <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
-
-    <!-- 最后更新时间插件 -->
-    <script src="https://cdn.jsdelivr.net/npm/docsify-updated/src/time-updater.min.js"></script>
 
     <!-- 插件：复制代码 / 图片缩放 / 分页 / emoji -->
     <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code"></script>


### PR DESCRIPTION
### 摘要
- 新增本地 `last-updated` 插件，通过 HEAD 请求读取 Markdown 的 `Last-Modified` 头部并渲染时间
- 去除对外部 `docsify-updated` CDN 的依赖，避免占位符无法替换

### 测试
- 未运行（文档渲染相关改动）

------
https://chatgpt.com/codex/tasks/task_e_68de2cc611a48333aefe060fa359e936