### PR TITLE
feat: 主页快速入口卡片化改版

### DIFF
--- a/Main_Page.md
+++ b/Main_Page.md
@@ -35,10 +35,40 @@
 
 ## 🔎 快速入口
 
-- [目录索引](index.md)：按主题浏览全部词条，适合系统化查阅。  
-- [术语表（Glossary）](Glossary.md)：快速确认术语定义，保持沟通一致。  
-- [更新日志](changelog.md)：追踪近期内容迭代与重要公告。  
-- [贡献指南](CONTRIBUTING.md)：了解如何参与、提交或改进条目。  
+<div class="quick-links-grid">
+  <a class="quick-link-card" href="index.md">
+    <div class="quick-link-icon">🧭</div>
+    <div class="quick-link-body">
+      <h3>目录索引</h3>
+      <p>按主题浏览全部词条，适合系统化查阅。</p>
+    </div>
+    <span class="quick-link-arrow">开始探索 →</span>
+  </a>
+  <a class="quick-link-card" href="Glossary.md">
+    <div class="quick-link-icon">📖</div>
+    <div class="quick-link-body">
+      <h3>术语表（Glossary）</h3>
+      <p>快速确认术语定义，保持沟通一致。</p>
+    </div>
+    <span class="quick-link-arrow">查阅术语 →</span>
+  </a>
+  <a class="quick-link-card" href="changelog.md">
+    <div class="quick-link-icon">🗞️</div>
+    <div class="quick-link-body">
+      <h3>更新日志</h3>
+      <p>追踪近期内容迭代与重要公告。</p>
+    </div>
+    <span class="quick-link-arrow">查看动态 →</span>
+  </a>
+  <a class="quick-link-card" href="CONTRIBUTING.md">
+    <div class="quick-link-icon">🛠️</div>
+    <div class="quick-link-body">
+      <h3>贡献指南</h3>
+      <p>了解如何参与、提交或改进条目。</p>
+    </div>
+    <span class="quick-link-arrow">加入贡献 →</span>
+  </a>
+</div>
 
 ---
 

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -240,6 +240,102 @@ button, .cover .buttons a{
   transform: translateY(-1px);
 }
 
+/* 快速入口区块 */
+.quick-links-grid{
+  margin-top: 1.2rem;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.quick-link-card{
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 22px;
+  background: var(--c-card);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid color-mix(in oklab, var(--c-muted) 18%, transparent);
+  box-shadow: 0 10px 24px rgba(79, 192, 141, 0.08);
+  transition: transform .18s ease, box-shadow .22s ease, border-color .22s ease;
+}
+
+.quick-link-card:hover{
+  transform: translateY(-4px);
+  border-color: color-mix(in oklab, var(--c-brand) 32%, transparent);
+  box-shadow: 0 18px 36px rgba(79, 192, 141, 0.18);
+}
+
+:root.dark .quick-link-card{
+  background: color-mix(in oklab, var(--c-card) 92%, rgba(20,27,35,.65));
+  border: 1px solid color-mix(in oklab, var(--c-muted) 32%, transparent);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, .46);
+}
+
+:root.dark .quick-link-card:hover{
+  border-color: color-mix(in oklab, var(--c-brand) 42%, transparent);
+  box-shadow: 0 20px 44px rgba(79, 192, 141, .28);
+}
+
+.quick-link-icon{
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background: linear-gradient(135deg,
+              color-mix(in oklab, var(--c-brand) 70%, #ffffff 35%),
+              color-mix(in oklab, var(--c-accent) 55%, #ffffff 30%));
+  color: var(--c-text);
+  box-shadow: 0 6px 14px rgba(79, 192, 141, 0.25);
+}
+
+:root.dark .quick-link-icon{
+  color: #F6FAFF;
+  background: linear-gradient(135deg,
+              color-mix(in oklab, var(--c-brand) 75%, rgba(30,37,50,.85)),
+              color-mix(in oklab, var(--c-accent) 60%, rgba(30,37,50,.75)));
+  box-shadow: 0 10px 22px rgba(79, 192, 141, 0.28);
+}
+
+.quick-link-body h3{
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 700;
+}
+
+.quick-link-body p{
+  margin: 0;
+  color: var(--c-muted);
+  font-size: .92rem;
+  line-height: 1.55;
+}
+
+:root.dark .quick-link-body p{
+  color: color-mix(in oklab, var(--c-muted) 88%, rgba(231,237,247,.75));
+}
+
+.quick-link-arrow{
+  margin-top: auto;
+  font-weight: 600;
+  font-size: .92rem;
+  color: color-mix(in oklab, var(--c-brand) 68%, var(--c-text));
+  transition: color .18s ease;
+}
+
+.quick-link-card:hover .quick-link-arrow{
+  color: var(--c-brand);
+}
+
+:root.dark .quick-link-arrow{
+  color: color-mix(in oklab, var(--c-brand) 62%, rgba(246,250,255,.82));
+}
+
 /* 表格美化 */
 .markdown-section table{
   border-collapse: separate;


### PR DESCRIPTION
## 概述
- 将首页“快速入口”模块改为四个卡片式导航，统一呈现标题、说明与行动按钮文案。
- 在 `assets/custom.css` 中新增卡片栅格、图标与悬停效果的样式，兼顾明暗主题的层次与阴影表现。

## 测试
- `python -m http.server 3000` 手动预览主页渲染效果。


------
https://chatgpt.com/codex/tasks/task_e_68de461c75108333a54acdb5ad7b0d35