### PR TITLE
fix: 修复主页主按钮在不同主题下的可见性

### DIFF
--- a/Main_Page.html
+++ b/Main_Page.html
@@ -88,7 +88,7 @@
         <a class="quick-link-card" href="Glossary.md">
           <div class="quick-link-icon">📖</div>
           <div class="quick-link-body">
-            <h3>术语表（Glossary）</h3>
+            <h3>术语表</h3>
             <p>快速确认常用术语。</p>
           </div>
           <span class="quick-link-arrow">查阅 →</span>

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -263,7 +263,13 @@ button, .cover .buttons a{
   margin-top: 1.2rem;
   display: grid;
   gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+@media (max-width: 640px){
+  .quick-links-grid{
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .quick-link-card{
@@ -526,20 +532,20 @@ button, .cover .buttons a{
 .btn--primary,
 .markdown-section .btn--primary{
   background: var(--c-brand);
-  color: #0f172a;
+  color: #ffffff;
   box-shadow: 0 12px 24px rgba(79,192,141,.28);
 }
 
 .btn--primary:visited,
 .markdown-section .btn--primary:visited{
-  color: #0f172a;
+  color: #ffffff;
 }
 
 .btn--primary:hover,
 .markdown-section .btn--primary:hover{
   transform: translateY(-2px);
   box-shadow: 0 16px 32px rgba(79,192,141,.34);
-  color: #041f15;
+  color: #ffffff;
 
 }
 

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -523,17 +523,20 @@ button, .cover .buttons a{
   transition: transform .18s ease, box-shadow .2s ease;
 }
 
-.btn--primary{
+.btn--primary,
+.markdown-section .btn--primary{
   background: var(--c-brand);
   color: #0f172a;
   box-shadow: 0 12px 24px rgba(79,192,141,.28);
 }
 
-.btn--primary:visited{
+.btn--primary:visited,
+.markdown-section .btn--primary:visited{
   color: #0f172a;
 }
 
-.btn--primary:hover{
+.btn--primary:hover,
+.markdown-section .btn--primary:hover{
   transform: translateY(-2px);
   box-shadow: 0 16px 32px rgba(79,192,141,.34);
   color: #041f15;


### PR DESCRIPTION
## 概要
- 调整主页主要按钮在 Markdown 渲染区域内的样式优先级，确保暗色与亮色模式下均能显示
- 同步更新按钮悬停与访问状态的文字颜色，避免被全局链接样式覆盖

## 测试
- npx docsify serve . --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68de65a7bd888333b9d37360ea9036b7