### PR TITLE
style: 重设计主页面页脚

### DIFF
--- a/Main_Page.html
+++ b/Main_Page.html
@@ -8,7 +8,6 @@
         我们专注于整理多重意识体系统（Plurality）与创伤相关主题的中文资料，融合社区经验、跨学科研究与可实践的工具。
         希望这份知识库能陪伴你理解自我、照顾伙伴，并与同路人建立连结。
       </p>
-      <p class="main-card__meta">维护者：脸脸系统 · 持续更新中</p>
     </div>
 
     <div class="main-card main-card--voices">
@@ -183,4 +182,9 @@
   </div>
 </div>
 
-<p class="main-footer">感谢每一位为多重意识体知识生态贡献力量的朋友，祝你在 Plurality Wiki 的旅程中获得启发、力量与陪伴。</p>
+<footer class="main-footer">
+  <div class="main-footer__inner">
+    <p class="main-footer__meta">维护者：脸脸系统 · 持续更新中</p>
+    <p class="main-footer__thanks">感谢每一位为多重意识体知识生态贡献力量的朋友，祝你在 Plurality Wiki 的旅程中获得启发、力量与陪伴。</p>
+  </div>
+</footer>

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -637,10 +637,50 @@ button, .cover .buttons a{
 }
 
 .main-footer{
-  margin: 2.5rem 0 1.5rem;
+  margin: 4rem 0 0;
+  padding: 36px 24px 44px;
+  background: color-mix(in oklab, var(--c-card) 94%, rgba(79,192,141,.1));
+  border-top: 1px solid color-mix(in oklab, var(--c-muted) 45%, transparent);
+}
+
+.main-footer__inner{
+  max-width: 880px;
+  margin: 0 auto;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   color: var(--c-muted);
   font-size: .95rem;
+}
+
+.main-footer__meta{
+  font-weight: 600;
+  color: var(--c-text);
+  letter-spacing: .02em;
+}
+
+.main-footer__thanks{
+  line-height: 1.6;
+}
+
+:root.dark .main-footer{
+  background: color-mix(in oklab, rgba(30,37,50,.92) 82%, var(--c-brand) 18%);
+  border-color: color-mix(in oklab, rgba(79,192,141,.5) 60%, transparent);
+}
+
+:root.dark .main-footer__inner{
+  color: color-mix(in oklab, var(--c-muted) 85%, rgba(240,246,255,.8));
+}
+
+:root.dark .main-footer__meta{
+  color: color-mix(in oklab, var(--c-brand) 68%, rgba(240,246,255,.92));
+}
+
+@media (max-width: 600px){
+  .main-footer{
+    padding: 28px 20px 36px;
+  }
 }
 
 @media (max-width: 600px){


### PR DESCRIPTION
## 摘要
- 将 Main_Page.html 底部的维护者信息与感谢语改为语义化页脚结构，并移出顶部简介卡片
- 为页脚设计新的背景、边框与排版样式，增强亮/暗色模式下的可读性

## 测试
- [x] `npx docsify serve . --port 3000` 手动预览页面

------
https://chatgpt.com/codex/tasks/task_e_68de6e938b58833391e83d602291467e