### PR TITLE
fix: 调整站点标题后缀显示

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <title>页面跳转中…</title>
+    <title>页面跳转中… - Plurality Wiki</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       body {

--- a/assets/title-suffix.js
+++ b/assets/title-suffix.js
@@ -1,0 +1,107 @@
+(function () {
+  "use strict";
+
+  var SITE_SUFFIX = " - Plurality Wiki";
+  var HOMEPAGE_TITLE = "首页";
+
+  function registerPlugin() {
+    window.$docsify = window.$docsify || {};
+    var originalPlugins = window.$docsify.plugins || [];
+    window.$docsify.plugins = [].concat(titleSuffixPlugin, originalPlugins);
+  }
+
+  function titleSuffixPlugin(hook, vm) {
+    hook.mounted(function () {
+      updateTitle(vm);
+    });
+
+    hook.doneEach(function () {
+      updateTitle(vm);
+    });
+  }
+
+  function updateTitle(vm) {
+    document.title = appendSuffix(resolvePageTitle(vm));
+  }
+
+  function appendSuffix(title) {
+    var base = (title || "").trim();
+    if (!base) {
+      base = "Plurality Wiki";
+    }
+    if (base.endsWith(SITE_SUFFIX)) {
+      return base;
+    }
+    return base + SITE_SUFFIX;
+  }
+
+  function resolvePageTitle(vm) {
+    var route = vm && vm.route ? vm.route : {};
+    var file = route.file || "";
+    var homepage = vm && vm.config ? vm.config.homepage : null;
+
+    if (isHomepageRoute(file, homepage, route)) {
+      return HOMEPAGE_TITLE;
+    }
+
+    var section = document.querySelector(".markdown-section");
+    if (section) {
+      var heading = section.querySelector("h1, h2, h3, h4, h5, h6");
+      if (heading) {
+        var text = heading.textContent.trim();
+        if (text) {
+          return text;
+        }
+      }
+    }
+
+    if (route && typeof route.title === "string" && route.title.trim()) {
+      return route.title.trim();
+    }
+
+    if (route && typeof route.path === "string" && route.path) {
+      return extractNameFromPath(route.path);
+    }
+
+    return "Plurality Wiki";
+  }
+
+  function isHomepageRoute(file, homepage, route) {
+    if (homepage && filesEqual(file, homepage)) {
+      return true;
+    }
+
+    if (!file && homepage) {
+      return true;
+    }
+
+    var path = route && route.path ? route.path : "";
+    if (!path || path === "/" || path === "#" || path === "#/") {
+      return true;
+    }
+
+    return false;
+  }
+
+  function extractNameFromPath(path) {
+    var clean = String(path || "");
+    clean = clean.replace(/^#?\/+/, "");
+    var parts = clean.split(/[?#]/)[0].split("/");
+    var last = parts.pop() || "";
+    var decoded = decodeURIComponent(last);
+    return decoded.replace(/\.(md|markdown|html)$/i, "").trim() || "Plurality Wiki";
+  }
+
+  function filesEqual(a, b) {
+    return normalizeFile(a) === normalizeFile(b);
+  }
+
+  function normalizeFile(input) {
+    return String(input || "")
+      .replace(/^\/+/, "")
+      .replace(/\\/g, "/")
+      .toLowerCase();
+  }
+
+  registerPlugin();
+})();

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>plurality_wiki</title>
+    <title>首页 - Plurality Wiki</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <!-- 基础主题（Docsify 官方） -->
@@ -226,6 +226,9 @@
 
     <!-- 自定义标题搜索（需在 Docsify 启动前注册插件） -->
     <script src="./assets/title-search.js"></script>
+
+    <!-- 页面标题后缀控制 -->
+    <script src="./assets/title-suffix.js"></script>
 
     <!-- 本地最后更新时间插件 -->
     <script src="./assets/last-updated.js"></script>


### PR DESCRIPTION
## 摘要
- 将首页默认标签标题更新为“首页 - Plurality Wiki”，并为 404 页面同步增加站点后缀
- 新增 Docsify 插件，在每次路由切换后为页面标题自动追加“ - Plurality Wiki”，并针对首页固定显示“首页 - Plurality Wiki”

## 测试
- 未执行（静态资源改动）

------
https://chatgpt.com/codex/tasks/task_e_68de79f7795c833389159cccd397a1f3