### PR TITLE
feat: 首页最近更新模块

### DIFF
--- a/Main_Page.html
+++ b/Main_Page.html
@@ -52,6 +52,16 @@
         <li><strong>持续更新：</strong>欢迎提出补充、纠错或改进建议，让资料保持准确。</li>
       </ul>
     </div>
+
+    <div class="main-card main-card--recent js-recent-home">
+      <h3>最近更新</h3>
+      <ul class="recent-updates-list js-recent-home-list">
+        <li class="recent-updates-item recent-updates-item--loading">加载中…</li>
+      </ul>
+      <p class="main-card__hint">
+        <a href="/recent">查看全部更新</a>
+      </p>
+    </div>
   </div>
 
   <div class="main-page-column main-page-column--right">

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -2,6 +2,7 @@
   - <a href="#" onclick="window.location.hash = '#/Main_Page.html'; return false;">首页</a>
   - [目录索引](index.md)
   - [术语表](Glossary.md)
+  - [最近更新](/recent)
 
 - **核心词条**
   - [多重意识体基础](entries/Plurality-Basics.md)

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -490,6 +490,52 @@ button, .cover .buttons a{
   margin-bottom: 0;
 }
 
+.main-card--recent .recent-updates-list{
+  list-style: none;
+  margin: .8rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+
+.recent-updates-item{
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.recent-updates-item a{
+  font-weight: 600;
+  color: color-mix(in oklab, var(--c-brand) 68%, var(--c-text));
+  text-decoration: none;
+}
+
+.recent-updates-item a:hover{
+  color: color-mix(in oklab, var(--c-brand) 82%, var(--c-text));
+  text-decoration: underline;
+}
+
+.recent-updates-meta{
+  font-size: .88rem;
+  color: var(--c-muted);
+}
+
+.recent-updates-item--loading,
+.recent-updates-item--empty,
+.recent-updates-item--error{
+  color: var(--c-muted);
+  font-size: .92rem;
+}
+
+:root.dark .recent-updates-item a{
+  color: color-mix(in oklab, var(--c-brand) 76%, rgba(246,250,255,.92));
+}
+
+:root.dark .recent-updates-item a:hover{
+  color: color-mix(in oklab, var(--c-brand) 88%, rgba(246,250,255,.96));
+}
+
 :root.dark .main-card{
   background: color-mix(in oklab, var(--c-card) 92%, rgba(20,27,35,.6));
   border: 1px solid color-mix(in oklab, var(--c-muted) 34%, transparent);

--- a/assets/recent-home.js
+++ b/assets/recent-home.js
@@ -1,0 +1,178 @@
+(function () {
+  const DATA_URL = "./assets/last-updated.json";
+  const LIMIT = 3;
+  const CARD_SELECTOR = ".js-recent-home";
+  const LIST_SELECTOR = ".js-recent-home-list";
+  const STATE_ATTR = "data-recent-home-initialized";
+
+  let updatesPromise = null;
+  const titleCache = new Map();
+
+  function fetchUpdates() {
+    if (!updatesPromise) {
+      updatesPromise = fetch(DATA_URL, { cache: "no-store" })
+        .then((response) => (response.ok ? response.json() : {}))
+        .catch(() => ({}));
+    }
+    return updatesPromise;
+  }
+
+  function toItems(map) {
+    return Object.keys(map || {})
+      .map((path) => ({ path, info: map[path] || {} }))
+      .filter((item) => item.info && item.info.updated)
+      .sort((a, b) => {
+        const aTime = new Date(a.info.updated).getTime();
+        const bTime = new Date(b.info.updated).getTime();
+        const aInvalid = Number.isNaN(aTime);
+        const bInvalid = Number.isNaN(bTime);
+        if (aInvalid && bInvalid) return 0;
+        if (aInvalid) return 1;
+        if (bInvalid) return -1;
+        return bTime - aTime;
+      })
+      .slice(0, LIMIT);
+  }
+
+  function toRoutePath(path) {
+    const withoutExt = path.replace(/\.md$/i, "");
+    const encoded = withoutExt
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    return `#/${encoded}`;
+  }
+
+  function fallbackTitle(path) {
+    const segments = path
+      .replace(/\.md$/i, "")
+      .split("/")
+      .filter(Boolean);
+    if (!segments.length) return path;
+    return segments[segments.length - 1].replace(/-/g, " ");
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function loadTitle(path) {
+    if (!path) return Promise.resolve("");
+    if (titleCache.has(path)) {
+      return titleCache.get(path);
+    }
+
+    const promise = fetch(`./${path}`, { cache: "no-store" })
+      .then((response) => {
+        if (!response.ok) throw new Error("Failed to load entry");
+        return response.text();
+      })
+      .then((text) => {
+        const match = text.match(/^#\s+(.+)$/m);
+        if (match && match[1]) {
+          return match[1].trim();
+        }
+        return fallbackTitle(path);
+      })
+      .catch(() => fallbackTitle(path));
+
+    titleCache.set(path, promise);
+    return promise;
+  }
+
+  function formatDate(isoString) {
+    if (!isoString) return "";
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return "";
+    const pad = (value) => String(value).padStart(2, "0");
+    const year = date.getFullYear();
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    return `${year}/${month}/${day}`;
+  }
+
+  function setLoading(list) {
+    if (!list) return;
+    list.innerHTML =
+      '<li class="recent-updates-item recent-updates-item--loading">加载中…</li>';
+  }
+
+  function render(list, items, isError) {
+    if (!list) return;
+
+    if (!items.length) {
+      const text = isError
+        ? "无法加载最近更新，请稍后再试。"
+        : "暂无最近更新。";
+      const stateClass = isError
+        ? "recent-updates-item--error"
+        : "recent-updates-item--empty";
+      list.innerHTML = `<li class="recent-updates-item ${stateClass}">${escapeHtml(
+        text
+      )}</li>`;
+      return;
+    }
+
+    const html = items
+      .map(({ path, info, title }) => {
+        const displayTitle = escapeHtml(title || fallbackTitle(path));
+        const href = toRoutePath(path);
+        const iso = info && info.updated ? escapeHtml(info.updated) : "";
+        const formattedDate = formatDate(info && info.updated);
+        const dateBlock = formattedDate
+          ? `<time datetime="${iso}">${escapeHtml(formattedDate)}</time>`
+          : "";
+        return `
+          <li class="recent-updates-item">
+            <a href="${href}">${displayTitle}</a>
+            ${dateBlock ? `<span class="recent-updates-meta">${dateBlock}</span>` : ""}
+          </li>
+        `;
+      })
+      .join("");
+
+    list.innerHTML = html;
+  }
+
+  function enhanceRecentCard() {
+    const container = document.querySelector(CARD_SELECTOR);
+    if (!container || container.getAttribute(STATE_ATTR) === "1") {
+      return;
+    }
+
+    const list = container.querySelector(LIST_SELECTOR);
+    if (!list) return;
+
+    container.setAttribute(STATE_ATTR, "1");
+    setLoading(list);
+
+    fetchUpdates()
+      .then((map) => {
+        const items = toItems(map);
+        return Promise.all(
+          items.map(async (item) => ({
+            ...item,
+            title: await loadTitle(item.path),
+          }))
+        );
+      })
+      .then((itemsWithTitle) => {
+        render(list, itemsWithTitle, false);
+      })
+      .catch(() => {
+        render(list, [], true);
+      });
+  }
+
+  window.$docsify = window.$docsify || {};
+  const userPlugins = window.$docsify.plugins || [];
+  window.$docsify.plugins = [].concat(function (hook) {
+    hook.doneEach(enhanceRecentCard);
+  }, userPlugins);
+})();

--- a/index.html
+++ b/index.html
@@ -315,6 +315,9 @@
       })();
     </script>
 
+    <!-- 首页最近更新模块 -->
+    <script src="./assets/recent-home.js"></script>
+
     <!-- 最近更新页面自动生成 -->
     <script src="./assets/recent-page.js"></script>
 


### PR DESCRIPTION
## Summary
- 在侧边栏增加“最近更新”入口，指向 `/recent` 页面
- 在首页新增最近更新卡片，自动展示最近三条更新词条并链接到全文
- 引入前端脚本与样式，从 `last-updated.json` 读取数据并补全词条标题与日期

## Testing
- 手动运行 `npx docsify serve . -p 3000` 进行本地预览

------
https://chatgpt.com/codex/tasks/task_e_68de895d1ab883338fb9c903d64dea59