### PR TITLE
feat: 扩充核心板块速览内容

### DIFF
--- a/Main_Page.html
+++ b/Main_Page.html
@@ -162,12 +162,14 @@
         <span class="badge">系统角色与类型</span>
         <span class="badge">系统体验与机制</span>
         <span class="badge">实践与支持</span>
+        <span class="badge">虚拟角色与文学影视作品</span>
       </div>
       <ul>
         <li><strong>诊断与临床：</strong>聚焦解离障碍、创伤后应激障碍、人格障碍等相关主题。</li>
         <li><strong>系统角色与类型：</strong>梳理成员角色定位、形成方式与协作方法。</li>
         <li><strong>系统体验与机制：</strong>讨论切换、共识、内部空间等机制。</li>
         <li><strong>实践与支持：</strong>整理冥想、接地等实务操作与同伴支持工具。</li>
+        <li><strong>虚拟角色与文学影视作品：</strong>涵盖文学、游戏、影视作品中与多意识体、解离、Tulpa 等相关的表现。</li>
       </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- 在首页核心板块速览中新增“虚拟角色与文学影视作品”徽章
- 补充对应板块简介，说明涵盖相关文学、游戏与影视表现

## Testing
- 未执行自动化测试（静态内容更新）

------
https://chatgpt.com/codex/tasks/task_e_68de94eb01d08333a62d1fb9fa08519e