### PR TITLE
fix: 调整侧边栏搜索栏位置

### DIFF
--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -114,7 +114,14 @@
     wrapper.appendChild(input);
     wrapper.appendChild(results);
 
-    sidebar.insertBefore(wrapper, sidebar.firstChild);
+    const brandElement = sidebar.querySelector(".app-name, .sidebar-brand");
+    if (brandElement && brandElement.parentNode) {
+      brandElement.parentNode.insertBefore(wrapper, brandElement.nextSibling);
+    } else if (sidebar.firstChild) {
+      sidebar.insertBefore(wrapper, sidebar.firstChild);
+    } else {
+      sidebar.appendChild(wrapper);
+    }
 
     input.addEventListener("focus", () => {
       ensureIndex(latestVM || {});


### PR DESCRIPTION
## 概述
- 调整 Docsify 侧边栏中标题搜索框的插入逻辑
- 确保搜索框显示在站点标题之后而非之前

## 测试
- 本地通过 `npx docsify serve . -p 3000` 预览确认布局

------
https://chatgpt.com/codex/tasks/task_e_68de9a4c3844833392dc0078a49fd6c4