### PR TITLE
fix: 修复 PDF 导出词条链接跳转

### DIFF
--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -17,8 +17,9 @@ cd tools/pdf_export && python -m pdf_export
 3. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
 4. 在合并内容前，会优先插入项目根目录下的 `Preface.md`（若存在且未被忽略），以确保 PDF 以《前言》开篇；
 5. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；在合并过程中会自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
-6. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
-7. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
+6. 自动识别 Markdown 中以 `entries/.../*.md` 形式书写的词条链接，并在合并时重写为指向 PDF 内部锚点的链接，确保离线文档中的交叉跳转仍可点击；
+7. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
+8. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 运行脚本前，请确保：
 


### PR DESCRIPTION
## Summary
- 为 PDF 导出流程补充词条链接识别与重写逻辑，将 `entries/.../*.md` 链接转换为文档内部锚点，维持离线跳转能力
- 更新导出说明文档，提醒脚本会自动处理词条间的链接

## Testing
- python -m compileall tools/pdf_export/export_to_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68dea173e4e08333a9d7156b59fe33e6