### PR TITLE
fix: 修复移动端搜索时侧边栏自动收起

### DIFF
--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -40,6 +40,27 @@
     });
   }
 
+  function isMobileLayout() {
+    if (typeof window === "undefined") return false;
+    if (typeof window.matchMedia === "function") {
+      return window.matchMedia("(max-width: 768px)").matches;
+    }
+    return window.innerWidth <= 768;
+  }
+
+  function closeSidebarOnMobile() {
+    if (!isMobileLayout()) return;
+    const body = document.body;
+    if (!body || body.classList.contains("close")) return;
+
+    const toggle = document.querySelector(".sidebar-toggle");
+    if (toggle && typeof toggle.click === "function") {
+      toggle.click();
+      return;
+    }
+    body.classList.add("close");
+  }
+
   function ensureIndex(vm) {
     if (!indexPromise) {
       indexPromise = buildIndex(vm).finally(function () {
@@ -221,6 +242,7 @@
         if (searchElements) {
           searchElements.input.blur();
         }
+        setTimeout(closeSidebarOnMobile, 0);
       });
 
       const meta = document.createElement("span");

--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -123,6 +123,22 @@
       sidebar.appendChild(wrapper);
     }
 
+    const stopPropagation = (event) => {
+      event.stopPropagation();
+    };
+
+    const registerLocalInteractionGuards = (element) => {
+      ["pointerdown", "touchstart", "mousedown", "click"].forEach(
+        (type) => {
+          element.addEventListener(type, stopPropagation);
+        }
+      );
+    };
+
+    registerLocalInteractionGuards(wrapper);
+    registerLocalInteractionGuards(input);
+    registerLocalInteractionGuards(results);
+
     input.addEventListener("focus", () => {
       ensureIndex(latestVM || {});
       if (input.value.trim()) {


### PR DESCRIPTION
## 概述
- 在自定义标题搜索组件中为搜索区域添加指针事件的冒泡屏蔽
- 避免移动端点击搜索框时触发 Docsify 的全局点击关闭逻辑，从而保持侧边栏展开

## 测试
- npx docsify serve . --port 3000（手动打开侧边栏并验证搜索框不再导致折叠）

------
https://chatgpt.com/codex/tasks/task_e_68df450b97c48333bac1e49b36a2bfe9