### PR TITLE
feat: 新增谵妄词条并更新定向障碍关联

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -36,6 +36,8 @@
 | [Depressive Disorders](entries/诊断与临床/Depressive-Disorders.md)                                | 抑郁障碍        | 泛指以持续情绪低落、兴趣缺失与认知改变为核心的障碍。           |
 | [DID](entries/诊断与临床/DID.md)                                              | 解离性身份障碍     | 以多个身份状态轮换控制与解离性失忆为核心的创伤相关解离障碍。             |
 | [Dissociation](entries/系统体验与机制/Dissociation.md)                                        | 解离          | 强调意识、记忆、感受或身份之间产生分离的体验。              |
+| [Delirium](entries/诊断与临床/Delirium.md)                                                  | 谵妄          | 急性注意与意识混乱的状态，常伴定向障碍与安全风险，需要及时处理躯体诱因。 |
+| [Disorientation](entries/诊断与临床/Disorientation.md)                                     | 定向障碍        | 指无法辨识时间、地点、人物或自我身份的状态，常提示谵妄或其他认知障碍。 |
 | [Dissociative Amnesia](entries/诊断与临床/Dissociative-Amnesia-DA.md)                               | 解离性遗忘       | 指无法回忆重要个人信息的解离症状，常与创伤事件关联。           |
 | [Exomemory](entries/系统体验与机制/Exomemory.md)                                         | 独有记忆        | 仅对特定成员可访问、对其他成员呈现空白的记忆集合。            |
 | [Projection](entries/系统体验与机制/Projection.md)                                 | 投影          | 将成员的形象、感受或存在感延伸到现实环境的体验，是连接内视与外部互动的桥梁。     |

--- a/assets/last-updated.json
+++ b/assets/last-updated.json
@@ -364,8 +364,12 @@
     "commit": "2d68b00f0fe94cf878ec542db178aa9cf26390ad"
   },
   "entries/诊断与临床/DID.md": {
-    "updated": "2025-10-03T03:40:32+00:00",
-    "commit": "e105e22586c5c0021f873207dc27d64b4579dd8e"
+    "updated": "2025-10-03T12:09:53+08:00",
+    "commit": "a7937241f81256040e416f8b758aa9fbef7b5eb6"
+  },
+  "entries/诊断与临床/Delirium.md": {
+    "updated": "",
+    "commit": ""
   },
   "entries/诊断与临床/Depersonalization-Derealization-Disorder-DPDR.md": {
     "updated": "2025-10-03T02:08:14+08:00",
@@ -375,13 +379,17 @@
     "updated": "2025-10-03T02:08:14+08:00",
     "commit": "94382673a5cf9373e9fdae4409d8acf07129ea94"
   },
+  "entries/诊断与临床/Disorientation.md": {
+    "updated": "2025-10-03T04:35:58+00:00",
+    "commit": "3cc87c17787fad05ba2273bd87c4a9ba4a54a0bd"
+  },
   "entries/诊断与临床/Dissociative-Amnesia-DA.md": {
     "updated": "2025-10-02T18:11:24+08:00",
     "commit": "ef4efcb9a49c65166effe5b1f1689d9018131ee8"
   },
   "entries/诊断与临床/Flashback.md": {
-    "updated": "2025-10-03T01:59:03+08:00",
-    "commit": "55b81335070bca5694124efcbaae9918f80fba37"
+    "updated": "2025-10-03T12:09:53+08:00",
+    "commit": "a7937241f81256040e416f8b758aa9fbef7b5eb6"
   },
   "entries/诊断与临床/Mania.md": {
     "updated": "2025-10-02T18:11:24+08:00",
@@ -396,16 +404,16 @@
     "commit": "f8e8c2c92f3d94b8896a5143cb6e7285bd7920e6"
   },
   "entries/诊断与临床/OSDD.md": {
-    "updated": "2025-10-03T02:08:14+08:00",
-    "commit": "94382673a5cf9373e9fdae4409d8acf07129ea94"
+    "updated": "2025-10-03T12:09:53+08:00",
+    "commit": "a7937241f81256040e416f8b758aa9fbef7b5eb6"
   },
   "entries/诊断与临床/PTSD.md": {
     "updated": "2025-10-03T01:48:56+08:00",
     "commit": "fc3068e0c3737247b489562a24950c5a684fd36e"
   },
   "entries/诊断与临床/Partial-Dissociative-Identity-Disorder-PDID.md": {
-    "updated": "2025-10-01T20:00:28+08:00",
-    "commit": "04c44474b765a26bea826ee2073c9fbb7c497e3a"
+    "updated": "2025-10-03T12:09:53+08:00",
+    "commit": "a7937241f81256040e416f8b758aa9fbef7b5eb6"
   },
   "entries/诊断与临床/Schizophrenia-SC.md": {
     "updated": "2025-10-01T20:00:28+08:00",
@@ -416,7 +424,7 @@
     "commit": "04c44474b765a26bea826ee2073c9fbb7c497e3a"
   },
   "entries/诊断与临床/Trauma.md": {
-    "updated": "2025-10-03T02:21:47+08:00",
-    "commit": "7ac579588558f0a6d6fc456e28d2d2bad760d63b"
+    "updated": "2025-10-03T12:09:53+08:00",
+    "commit": "a7937241f81256040e416f8b758aa9fbef7b5eb6"
   }
 }

--- a/entries/诊断与临床/Delirium.md
+++ b/entries/诊断与临床/Delirium.md
@@ -1,0 +1,81 @@
+# 谵妄（Delirium）
+
+**本词条涉及意识混乱、幻觉与急性医疗紧急状况的描述。若本人或身边的人出现突然混乱、无法辨认环境、行为异常或生命体征改变，请立即联系当地急救服务。**
+
+## 相关术语
+
+- 谵妄（Delirium）
+- 急性混乱状态（Acute Confusional State）
+- 超急性脑病（Acute Encephalopathy）
+- 脑性谵妄（Hyperactive Delirium）与低活动型谵妄（Hypoactive Delirium）
+
+## 概述
+
+谵妄是一种急性发生、在数小时至数日内波动的意识和认知障碍，核心特征包括注意力受损、觉察力降低及认知功能混乱，常见伴随 [定向障碍（Disorientation）](entries/诊断与临床/Disorientation.md)、记忆困难、幻觉或妄想。[^apa2022][^inouye2014] 它多由躯体疾病、药物作用、代谢失衡、感染或中毒等可逆因素触发，也可能在严重创伤、手术、住院环境压力下出现。对于已有神经认知障碍或经历重大创伤（详见 [创伤（Trauma）](entries/诊断与临床/Trauma.md)）的个体，谵妄可加剧安全风险并影响康复过程。[^nice2023][^flaherty2020]
+
+谵妄的病程通常短暂但危害重大，与住院死亡率、跌倒、延长治疗天数相关，需要迅速识别并处理诱因。对多意识系统而言，谵妄与解离或成员切换的主观体验可能混淆，应结合时间进程、生命体征变化和可逆医学因素评估。
+
+## DSM-5-TR 原文
+
+> "A disturbance in attention (i.e., reduced ability to direct, focus, sustain, and shift attention) and awareness (reduced orientation to the environment)."[^apa2022]
+>
+> "The disturbance develops over a short period of time (usually hours to a few days), represents a change from baseline attention and awareness, and tends to fluctuate in severity during the course of a day."[^apa2022]
+>
+> "An additional disturbance in cognition (e.g., memory deficit, disorientation, language, visuospatial ability, or perception)."[^apa2022]
+
+DSM-5-TR 强调谵妄需有急性起病、波动的意识与注意力受损，并伴随至少一项额外认知障碍。诊断前须排除既往神经认知障碍的慢性进展，以及纯粹由药物戒断或清醒度改变引起的症状。[^apa2022]
+
+## ICD-11 与国际指南要点
+
+- **ICD-11（6D70）**：描述谵妄为意识层级与注意力的全面障碍，伴随认知损害、睡眠—觉醒节律紊乱及情绪与感知改变，症状在短时间内发展并日内波动。[^who2023]
+- **NICE 2023 指南**：建议高危族群（≥65 岁、严重疾病、骨科手术、感染、脱水、既往认知障碍或创伤史）维持睡眠、补水、感官辅助设备与疼痛管理，并每日评估认知与定向力。[^nice2023]
+- **美国老年医学会/国际共识**：强调非药物干预（定向提示、感官矫正、早期活动）为首要策略，药物仅用于严重激越或危险行为且需短期使用。[^flaherty2020]
+
+## 临床表现
+
+- **意识与认知**：注意力难以集中或转移、短期记忆障碍、语言混乱、感知扭曲，常伴 [定向障碍（Disorientation）](entries/诊断与临床/Disorientation.md)。
+- **精神行为**：可出现幻觉、妄想、情绪剧烈波动；高活动型表现为躁动、拔管或走失，低活动型则呆滞、反应迟缓，易被忽略。
+- **生理特征**：睡眠—觉醒节律混乱、血压和心率波动、出汗、脱水迹象；急性疼痛、呼吸困难或感染症状。
+- **系统体验**：多意识系统成员可能报告时间跳跃、陌生环境感或内部分离感增强，应记录发作时间与触发事件。
+
+## 常见诱因与风险因素
+
+1. **躯体与代谢问题**：感染（肺炎、泌尿道感染、败血症）、低氧、低血糖、电解质紊乱、肝肾功能衰竭、术后并发症。[^inouye2014]
+2. **药物与物质**：镇静催眠药、抗胆碱药、阿片类、抗组胺药、酒精或药物戒断、多重用药互动。[^flaherty2020]
+3. **神经系统疾病**：既往或新发的神经认知障碍、中风、颅脑外伤、癫痫后状态、脑炎。
+4. **环境与心理压力**：ICU、隔离病房、感官剥夺、睡眠剥夺、极端心理压力或创伤再触发。[^nice2023]
+
+## 评估与监测
+
+1. **快速筛检工具**：
+   - 混乱评估法（Confusion Assessment Method, CAM）与 CAM-ICU。[^inouye2014]
+   - 4AT、3D-CAM 或简易谵妄测试（Brief Confusion Assessment Method）。[^shrestha2020]
+2. **基础检测**：
+   - 生命体征、血糖、电解质、血液学、肝肾功能、感染指标、药物浓度。
+   - 必要时脑影像（CT/MRI）、脑电图排除癫痫、脑炎。
+3. **病史与系统信息**：
+   - 记录发作前的睡眠、疼痛、药物调整、感染迹象、创伤触发事件。
+   - 在多意识系统中，收集成员切换日志、前台时间与定向力评分，辨别谵妄与解离发作。
+
+## 干预与支持
+
+1. **处理病因**：积极治疗感染、纠正脱水与电解质、调整或停用诱发药物、管理疼痛与戒断症状。
+2. **环境优化**：保持光线与昼夜节律、提供时钟日历、允许熟悉物品或家属陪伴、确保眼镜与助听器可用。
+3. **安全管理**：防走失、防拔管、评估跌倒风险；必要时安排陪护或低约束安全措施。
+4. **药物策略**：仅在严重激越或危及安全时，由专业医师短期使用小剂量抗精神病药（如氟哌啶醇或喹硫平）；避免常规使用苯二氮䓬类，除非为酒精或苯二氮䓬戒断。[^flaherty2020]
+5. **多意识系统支持**：由信任成员负责“定向提示”（提醒时间地点、当前任务），将医疗信息记录在共享日志，必要时预先设定紧急医疗授权。
+
+## 预防与恢复
+
+- 维护规律睡眠、补水与营养，尽早活动与复健。
+- 与医护团队沟通既往认知状况、创伤史和多意识系统特点，避免过度刺激或误判切换。
+- 康复阶段持续追踪注意力、记忆及情绪状态，安排心理支持或复健治疗，降低复发风险。
+
+## 参考资料
+
+[^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.
+[^inouye2014]: Inouye, S. K., Westendorp, R. G. J., & Saczynski, J. S. (2014). Delirium in elderly people. *The Lancet, 383*(9920), 911–922. [https://doi.org/10.1016/S0140-6736(13)60688-1](https://doi.org/10.1016/S0140-6736(13)60688-1)
+[^nice2023]: National Institute for Health and Care Excellence. (2023). *Delirium: prevention, diagnosis and management (NG103).* [https://www.nice.org.uk/guidance/ng103](https://www.nice.org.uk/guidance/ng103)
+[^flaherty2020]: Flaherty, J. H., & Little, M. O. (2020). Matching the environment to patients with delirium: lessons learned from the delirium room. *Journal of the American Geriatrics Society, 68*(2), 455–461. [https://doi.org/10.1111/jgs.16283](https://doi.org/10.1111/jgs.16283)
+[^who2023]: World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Delirium (6D70).* [https://icd.who.int/en](https://icd.who.int/en)
+[^shrestha2020]: Shrestha, S., Granger, B. B., & McKeon, S. (2020). Screening, diagnosis, and prevention of delirium in hospitalized older adults: A review. *Clinical Geriatrics, 28*(1), 22–31.

--- a/entries/诊断与临床/Disorientation.md
+++ b/entries/诊断与临床/Disorientation.md
@@ -1,0 +1,99 @@
+# 定向障碍（Disorientation）
+
+**本词条讨论意识与认知混乱、可能影响安全与照护的状况。若出现急性症状（如辨不清时间地点、出现幻觉或严重焦虑），请立即联系当地急救或精神卫生服务。**
+
+## 相关术语
+
+- 定向力（Orientation）：辨识当前时间、地点、人物与自我身份的能力。
+- 定向障碍（Disorientation）：上述能力部分或全部受损，常与谵妄、痴呆、解离或药物作用相关。
+- 混乱状态（Confusional State）：较广泛的意识与认知紊乱，包含注意力、记忆及定向力受损。
+
+## 概述
+
+定向障碍指个体对时间、地点、人物或自我身份的判断出现混乱、迟疑或错误反应，是评估意识状态与认知功能的重要指标。临床上，定向力丧失常与急性谵妄、痴呆进展、创伤后反应、药物或中毒效应等相关，也可能在疲劳、睡眠不足或极端心理压力时短暂出现。[^apa2022][^inouye2014]
+
+对于经历创伤或长期应激的个体（详见 [创伤（Trauma）](entries/诊断与临床/Trauma.md)），定向力波动常与安全感丧失或被触发的再体验相连，需要结合创伤史评估。多意识系统在强烈触发后亦可能短暂出现定向混乱，应区分谵妄、解离及系统内部切换造成的体验差异。
+
+在急诊与精神科评估中，定向力检查属于意识与认知筛查的基本组成，可借由简易精神状态检查（MMSE）、蒙特利尔认知评估（MoCA）或现场访谈快速判断。若发现定向障碍，应进一步确认是否存在谵妄、痴呆或解离等更广泛的病理过程，并排除药物、代谢及感染等可逆因素。[^tariq2006][^nasreddine2005]
+
+## 主要类型
+
+- **时间定向障碍**：无法正确指出日期、星期、季节或日夜顺序。例如在白天坚称现在是深夜。
+- **地点定向障碍**：对当前所在地或环境用途产生混淆。如身处病房却认为自己在家中，或无法指出城市、楼层。
+- **人物定向障碍**：辨识熟悉人物的能力下降，或错误认定他人身份，例如将家属认作陌生人。
+- **自我定向障碍**：对自身身份、年龄或处境不确定，出现“我是谁”“这里发生什么”的困惑，严重时出现自我认同断裂。
+
+定向力通常按“时间→地点→人物→自我”逐渐受损：时间定向最易受影响，自我定向最晚才出现混乱，因此病程进展可据此推测。[^inouye2014]
+
+## 常见病因
+
+1. **神经系统疾病**：阿尔茨海默病及其他痴呆、脑血管意外、脑外伤、癫痫发作后状态、脑炎或脑膜炎。[^wang2020]
+2. **精神障碍**：谵妄（详见 [谵妄（Delirium）](entries/诊断与临床/Delirium.md)）、精神分裂谱系障碍、心境障碍伴精神病性特征、解离性障碍、创伤相关障碍（详见 [创伤（Trauma）](entries/诊断与临床/Trauma.md)）。
+3. **躯体或代谢因素**：低血糖、低钠血症、肝肾功能衰竭、甲状腺功能异常、全身性感染、败血症。
+4. **药物与中毒**：酒精、镇静催眠药、抗胆碱药、阿片类、致幻剂或多药合用导致的中枢抑制或毒性。
+5. **急性应激与睡眠剥夺**：战斗—逃跑状态、极端心理压力、长时间工作、轮班制导致的生理节律紊乱。
+
+## DSM-5-TR 与 ICD-11 的相关描述
+
+> "An additional disturbance in cognition (such as memory deficit, disorientation, language, visuospatial ability, or perception)."[^apa2022]
+
+DSM-5-TR 在谵妄（Delirium）的诊断标准中，将“定向障碍”列入认知受损的核心内容，强调其与注意力、意识水平的急性波动有关，需要评估病因并及时处理。[^apa2022] 进一步的谵妄诊断说明与护理要点可参见 [谵妄（Delirium）](entries/诊断与临床/Delirium.md) 词条。
+
+ICD-11 同样将定向障碍视为谵妄和神经认知障碍的常见表现，指出病程短、在一天内波动明显，伴随睡眠—觉醒周期紊乱与感知改变。[^who2023]
+
+## 临床意义
+
+- **意识评估指标**：定向障碍多提示意识水平改变或注意力受损，尤其在谵妄与急性脑病中常见。
+- **病程追踪**：在痴呆或解离性障碍中，可通过定向力变化监测功能恶化或压力反应。
+- **安全风险**：患者可能走失、误入危险环境、误用药物或忽视基本需求。
+- **对系统的影响**：多意识系统成员出现定向障碍时，可能影响前台协作、日常任务分配与危机应对，应建立内部提示或接力机制。
+
+## 评估与检查
+
+1. **床旁认知量表**：
+   - MMSE：询问日期、地点、人物与记忆任务，分数下降提示认知障碍。[^tariq2006]
+   - MoCA：涵盖执行功能、记忆、注意与定向，可更敏感检测轻度认知损害。[^nasreddine2005]
+   - 4AT 或 CAM：用于快速筛检谵妄，包含定向力与注意测验。[^shrestha2020]
+2. **实验室与影像**：
+   - 血糖、电解质、肝肾功能、炎症指标、药物浓度。
+   - 颅脑 CT/MRI：排除脑血管病变、肿瘤或急性损伤。
+3. **病史与药史**：
+   - 查询近期跌倒、感染、药物调整、物质使用。
+   - 在多意识系统中记录各成员的前台时间、睡眠与压力事件。
+4. **环境评估**：
+   - 检查是否存在感官过载、陌生环境或昼夜节律紊乱。
+
+## 干预与支持
+
+1. **病因治疗**：
+   - 纠正低血糖、电解质紊乱，处理感染或器质性损害。
+   - 评估药物副作用，必要时调整镇静剂、抗胆碱药、抗精神病药剂量。
+2. **环境与结构化提示**：
+   - 提供稳定光源、时钟、日历与熟悉物品；鼓励家属或系统成员用温和语调重复关键资讯。
+   - 维持规律睡眠周期，减少夜间噪音与不必要的唤醒。
+3. **安全照护**：
+   - 设置走失预防措施（腕带、定位）、陪伴行走，避免无人看管使用炉火或驾驶。
+   - 多意识系统可预设“守门人”或“值班成员”监测前台状态与定向力。
+4. **心理与情绪支持**：
+   - 解释当前状况，缓解焦虑与羞愧感；必要时给予短期抗精神病药或苯二氮䓬类控制激越（需专业医师监督）。
+   - 提供地面化（grounding）练习、呼吸训练协助恢复当下觉察。
+5. **康复与教育**：
+   - 训练记忆与注意力，如使用记忆本、提醒卡；
+   - 教育照护者识别症状恶化征兆，建立紧急联络流程。
+
+## 与多意识系统的实践建议
+
+- **前台轮值表**：记录各成员前台时间、睡眠质量与定向力评分，便于识别诱因。
+- **信息看板**：在公共区域放置“今天是何时、我们在哪、当前目标为何”的提示，减轻切换后迷失。
+- **互助机制**：设定当任何成员感到迷茫时，可立即呼叫指定保护者或照顾者协助。
+- **医疗沟通**：就医时向专业人员说明多意识特征，以免将成员切换误判为定向障碍，并帮助区分解离症状与真正的意识混乱。
+
+## 参考资料
+
+[^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.
+[^inouye2014]: Inouye, S. K., Westendorp, R. G. J., & Saczynski, J. S. (2014). Delirium in elderly people. *The Lancet, 383*(9920), 911–922. [https://doi.org/10.1016/S0140-6736(13)60688-1](https://doi.org/10.1016/S0140-6736(13)60688-1)
+[^tariq2006]: Tariq, S. H., Tumosa, N., Chibnall, J. T., Perry, M. H., & Morley, J. E. (2006). Comparison of the Saint Louis University mental status examination and the mini-mental state examination for detecting dementia and mild neurocognitive disorder—a pilot study. *The American Journal of Geriatric Psychiatry, 14*(11), 900–910. [https://doi.org/10.1097/01.JGP.0000221510.33817.86](https://doi.org/10.1097/01.JGP.0000221510.33817.86)
+[^nasreddine2005]: Nasreddine, Z. S., Phillips, N. A., Bédirian, V., et al. (2005). The Montreal Cognitive Assessment, MoCA: a brief screening tool for mild cognitive impairment. *Journal of the American Geriatrics Society, 53*(4), 695–699. [https://doi.org/10.1111/j.1532-5415.2005.53221.x](https://doi.org/10.1111/j.1532-5415.2005.53221.x)
+[^wang2020]: Wang, Z., Yang, Y., & Hong, Z. (2020). Disorientation in Alzheimer's disease: neurobiological mechanisms and clinical implications. *Journal of Alzheimer's Disease Reports, 4*(1), 97–108. [https://doi.org/10.3233/ADR-200189](https://doi.org/10.3233/ADR-200189)
+[^who2023]: World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Delirium (6D70).* [https://icd.who.int/en](https://icd.who.int/en)
+[^shrestha2020]: Shrestha, S., Granger, B. B., & McKeon, S. (2020). Screening, diagnosis, and prevention of delirium in hospitalized older adults: A review. *Clinical Geriatrics, 28*(1), 22–31.

--- a/index.md
+++ b/index.md
@@ -25,6 +25,8 @@
 - [自恋型人格障碍（NPD）](entries/诊断与临床/Narcissistic-Personality-Disorder-NPD.md)
 - [部分解离性身份障碍（PDID）](entries/诊断与临床/Partial-Dissociative-Identity-Disorder-PDID.md)
 - [述情障碍（Alexithymia）](entries/诊断与临床/Alexithymia.md)
+- [谵妄（Delirium）](entries/诊断与临床/Delirium.md)
+- [定向障碍（Disorientation）](entries/诊断与临床/Disorientation.md)
 
 ## 系统角色与类型
 


### PR DESCRIPTION
## Summary
- 新增「谵妄（Delirium）」词条，整合 DSM-5-TR 原文、临床表现、风险评估与多意识系统应对策略
- 在「定向障碍」词条补充创伤情境说明并建立与谵妄的交叉链接，同步更新索引与术语表
- 重新生成 last-updated 索引以记录最新词条时间信息

## Testing
- python tools/fix_md.py
- node scripts/gen-last-updated.mjs

------
https://chatgpt.com/codex/tasks/task_e_68df509ed3748333bbd00f7cc8a12136