### PR TITLE
docs: 为前端资产脚本补充注释

### DIFF
--- a/assets/recent-home.js
+++ b/assets/recent-home.js
@@ -8,6 +8,7 @@
   let updatesPromise = null;
   const titleCache = new Map();
 
+  // 从 last-updated.json 拉取最近更新数据，并复用同一 Promise 防止重复请求
   function fetchUpdates() {
     if (!updatesPromise) {
       updatesPromise = fetch(DATA_URL, { cache: "no-store" })
@@ -17,6 +18,7 @@
     return updatesPromise;
   }
 
+  // 将原始更新信息整理成按更新时间倒序排序且数量受限的卡片列表
   function toItems(map) {
     return Object.keys(map || {})
       .map((path) => ({ path, info: map[path] || {} }))
@@ -34,6 +36,7 @@
       .slice(0, LIMIT);
   }
 
+  // 将词条相对路径转成 Docsify 需要的 hash 形式，兼容中文与特殊字符
   function toRoutePath(path) {
     const withoutExt = path.replace(/\.md$/i, "");
     const encoded = withoutExt
@@ -44,6 +47,7 @@
     return `#/${encoded}`;
   }
 
+  // 若无法解析 Markdown 标题时，回退使用路径末段作为展示文案
   function fallbackTitle(path) {
     const segments = path
       .replace(/\.md$/i, "")
@@ -53,6 +57,7 @@
     return segments[segments.length - 1].replace(/-/g, " ");
   }
 
+  // 基础的 HTML 转义，避免用户生成内容打破结构
   function escapeHtml(value) {
     return String(value)
       .replace(/&/g, "&amp;")
@@ -62,6 +67,7 @@
       .replace(/'/g, "&#39;");
   }
 
+  // 异步加载 Markdown，缓存 Promise 并提取一级标题作为卡片标题
   function loadTitle(path) {
     if (!path) return Promise.resolve("");
     if (titleCache.has(path)) {
@@ -86,6 +92,7 @@
     return promise;
   }
 
+  // 将 ISO 字符串格式化为 YYYY/MM/DD，供卡片右下角展示
   function formatDate(isoString) {
     if (!isoString) return "";
     const date = new Date(isoString);
@@ -97,12 +104,14 @@
     return `${year}/${month}/${day}`;
   }
 
+  // 在真实数据返回前展示加载态，提升感知反馈
   function setLoading(list) {
     if (!list) return;
     list.innerHTML =
       '<li class="recent-updates-item recent-updates-item--loading">加载中…</li>';
   }
 
+  // 根据数据渲染列表，如无数据或请求失败则输出对应提示
   function render(list, items, isError) {
     if (!list) return;
 
@@ -140,6 +149,7 @@
     list.innerHTML = html;
   }
 
+  // 将首页最近更新卡片接入数据源，仅初始化一次避免重复绑定
   function enhanceRecentCard() {
     const container = document.querySelector(CARD_SELECTOR);
     if (!container || container.getAttribute(STATE_ATTR) === "1") {

--- a/assets/recent-page.js
+++ b/assets/recent-page.js
@@ -6,6 +6,7 @@
 
   let cachedPromise = null;
 
+  // 读取 last-updated.json 并利用缓存 Promise 避免多次网络请求
   function fetchUpdates() {
     if (!cachedPromise) {
       cachedPromise = fetch(DATA_URL, { cache: "no-store" })
@@ -15,6 +16,7 @@
     return cachedPromise;
   }
 
+  // 将词条路径转换为 Docsify 可识别的 hash 链接，确保中文安全编码
   function toRoutePath(filePath) {
     const withoutExt = filePath.replace(/\.md$/i, "");
     const encoded = withoutExt
@@ -27,6 +29,7 @@
 
   let titleCachePromise = null;
 
+  // 从 index.md 提取侧边链接，构建路径与标题的映射缓存
   function fetchTitleMap() {
     if (!titleCachePromise) {
       titleCachePromise = fetch("./index.md", { cache: "no-store" })
@@ -49,6 +52,7 @@
     return titleCachePromise;
   }
 
+  // 优先使用索引中的标题，否则用路径末段回退展示
   function toDisplayName(filePath, titleMap) {
     if (titleMap && titleMap[filePath]) {
       return titleMap[filePath];
@@ -59,6 +63,7 @@
     return decodeURIComponent(lastSegment).replace(/-/g, " ");
   }
 
+  // 按 YYYY/MM/DD HH:mm 输出更新时间，展示在最近更新列表
   function formatDate(isoString) {
     if (!isoString) return "";
     const date = new Date(isoString);
@@ -72,6 +77,7 @@
     return `${year}/${month}/${day} ${hours}:${minutes}`;
   }
 
+  // 标准化 Docsify 路径对象，保证匹配 /recent 路由时不受尾部斜杠影响
   function normalizeRoutePath(route) {
     if (!route || !route.path) return "";
     const [path] = String(route.path).split("?");
@@ -80,6 +86,7 @@
     return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
   }
 
+  // 构造指向仓库提交的外链，截取前 7 位作为短哈希
   function buildCommitLink(commit) {
     if (!commit) return "";
     const repo = (window.$docsify && window.$docsify.repo) || "";
@@ -96,6 +103,7 @@
     )}</a>`;
   }
 
+  // 生成完整的 HTML 片段，缺省时展示友好提示
   function renderList(items, titleMap) {
     if (!items.length) {
       return `
@@ -134,6 +142,7 @@
     `;
   }
 
+  // 根据更新时间排序并裁剪条目，传递给渲染函数
   function generateContent(map, titleMap) {
     const items = Object.keys(map || {})
       .map((path) => ({ path, info: map[path] || {} }))

--- a/assets/title-search.js
+++ b/assets/title-search.js
@@ -7,6 +7,7 @@
   let indexReady = false;
   let latestVM = null;
 
+  // 注册标题搜索插件，确保 formatUpdated 默认值存在
   function registerPlugin() {
     window.$docsify = window.$docsify || {};
     if (!window.$docsify.formatUpdated) {
@@ -16,6 +17,7 @@
     window.$docsify.plugins = [].concat(titleSearchPlugin, originalPlugins);
   }
 
+  // 通过 Docsify 生命周期钩子维护标题索引与交互行为
   function titleSearchPlugin(hook, vm) {
     latestVM = vm;
 
@@ -61,6 +63,7 @@
     body.classList.add("close");
   }
 
+  // 构建索引的惰性触发器，避免并发重复执行
   function ensureIndex(vm) {
     if (!indexPromise) {
       indexPromise = buildIndex(vm).finally(function () {
@@ -70,6 +73,7 @@
     return indexPromise;
   }
 
+  // 读取首页、索引与侧边栏 Markdown，提取所有标题供搜索使用
   async function buildIndex(vm) {
     const base = resolveBasePath(vm);
     const paths = new Set();
@@ -113,6 +117,7 @@
     await Promise.all(tasks);
   }
 
+  // 按需在侧边栏插入搜索输入框并绑定交互
   function ensureSearchElements() {
     if (searchElements && searchElements.input.isConnected) {
       return;
@@ -188,6 +193,7 @@
     searchElements = { wrapper, input, results };
   }
 
+  // 根据关键字匹配标题索引，渲染下拉面板
   function renderResults(keyword) {
     if (!searchElements) return;
     const { results } = searchElements;

--- a/assets/title-suffix.js
+++ b/assets/title-suffix.js
@@ -4,12 +4,14 @@
   var SITE_SUFFIX = " - Plurality Wiki";
   var HOMEPAGE_TITLE = "首页";
 
+  // 将标题后缀插件注册进 Docsify，保持原有插件顺序
   function registerPlugin() {
     window.$docsify = window.$docsify || {};
     var originalPlugins = window.$docsify.plugins || [];
     window.$docsify.plugins = [].concat(titleSuffixPlugin, originalPlugins);
   }
 
+  // 在首次挂载与路由切换后刷新页面标题
   function titleSuffixPlugin(hook, vm) {
     hook.mounted(function () {
       updateTitle(vm);
@@ -20,10 +22,12 @@
     });
   }
 
+  // 读取当前路由标题并附加站点后缀
   function updateTitle(vm) {
     document.title = appendSuffix(resolvePageTitle(vm));
   }
 
+  // 保证标题存在且仅追加一次站点名称
   function appendSuffix(title) {
     var base = (title || "").trim();
     if (!base) {
@@ -35,6 +39,7 @@
     return base + SITE_SUFFIX;
   }
 
+  // 根据当前路由、文档结构和路径推断最合适的标题
   function resolvePageTitle(vm) {
     var route = vm && vm.route ? vm.route : {};
     var file = route.file || "";
@@ -66,6 +71,7 @@
     return "Plurality Wiki";
   }
 
+  // 判断当前路由是否首页，用于返回固定标题
   function isHomepageRoute(file, homepage, route) {
     if (homepage && filesEqual(file, homepage)) {
       return true;
@@ -83,6 +89,7 @@
     return false;
   }
 
+  // 从路径末尾提取文件名，兼容编码与后缀
   function extractNameFromPath(path) {
     var clean = String(path || "");
     clean = clean.replace(/^#?\/+/, "");
@@ -92,10 +99,12 @@
     return decoded.replace(/\.(md|markdown|html)$/i, "").trim() || "Plurality Wiki";
   }
 
+  // 对比两个文件名是否等价，忽略大小写与起始斜杠
   function filesEqual(a, b) {
     return normalizeFile(a) === normalizeFile(b);
   }
 
+  // 标准化文件路径，供比较使用
   function normalizeFile(input) {
     return String(input || "")
       .replace(/^\/+/, "")

--- a/assets/typography.js
+++ b/assets/typography.js
@@ -22,6 +22,7 @@
     "TEXTAREA",
   ]);
 
+  // 检测文本是否命中中西文混排模式，命中则需要插入空格
   function needsSpacing(value) {
     return spacingRules.some((rule) => {
       rule.lastIndex = 0;
@@ -29,6 +30,7 @@
     });
   }
 
+  // 对文本按规则插入空格，保持原有顺序逐条替换
   function applySpacingToText(value) {
     let result = value;
     for (const rule of spacingRules) {
@@ -37,6 +39,7 @@
     return result;
   }
 
+  // 跳过代码块等不应自动加空格的节点，支持通过 class 手动关闭
   function shouldSkipNode(node, root) {
     let current = node.parentNode;
     while (current && current !== root) {
@@ -55,6 +58,7 @@
     return false;
   }
 
+  // 遍历容器内所有文本节点并按需添加空格
   function processContainer(root) {
     if (!root) return;
 
@@ -89,6 +93,7 @@
     }
   }
 
+  // 渲染完成后延迟执行，避免与 Docsify 更新冲突
   function scheduleSpacing() {
     const container = document.querySelector(".markdown-section");
     if (!container) return;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 
     <script>
       (function () {
+        // Docsify 在计算 basePath 时默认以斜杠结尾，这里显式补齐以兼容任意部署路径
         const ensureTrailingSlash = (path) =>
           path.endsWith("/") ? path : `${path}/`;
         const { pathname } = window.location;
@@ -32,6 +33,7 @@
           "/.*/_sidebar.md": "_sidebar.md",
         };
 
+        // 手动移除 ./ 与 .. 片段，保证 hash 与跳转路径保持规范化
         const normalizePath = (raw) => {
           const [rawPath, query = ""] = raw.split("?");
           const segments = rawPath.split("/").filter(Boolean);
@@ -49,6 +51,7 @@
           return normalizedPath + (query ? `?${query}` : "");
         };
 
+        // 将 hash 统一整理成 #/xxx 形式，避免 Docsify 路由因重复字符而失效
         const canonicalizeHash = (() => {
           let adjusting = false;
 
@@ -56,6 +59,7 @@
             const { origin, pathname, search } = window.location;
             const newUrl = `${origin}${pathname}${search}${hash}`;
 
+            // 使用 adjusting 标记避免 history.replaceState 再次触发监听器导致无限循环
             adjusting = true;
             history.replaceState(null, "", newUrl);
 
@@ -92,6 +96,7 @@
         );
         canonicalizeHash();
 
+        // 仅拦截站内链接，外部链接或协议链接交回浏览器处理
         const shouldHandleInternally = (href) => {
           if (!href || href.startsWith("#")) return false;
           if (/^[a-zA-Z]+:/i.test(href)) return false;
@@ -99,6 +104,7 @@
           return true;
         };
 
+        // 将 Markdown 链接解析成 Docsify 需要的 hash 形式，并兼容 #锚点
         const resolveTarget = (href) => {
           const [pathAndQuery = "", hashFragment = ""] = href.split("#");
           const [rawPath = "", rawQuery = ""] = pathAndQuery.split("?");


### PR DESCRIPTION
## 摘要
- 为首页最近更新组件的脚本添加中文注释，说明缓存策略与渲染流程
- 为最近更新页面、标题搜索/后缀和排版插件补充说明，便于后续维护

## 测试
- 未执行自动化测试（仅更新注释）

------
https://chatgpt.com/codex/tasks/task_e_68dfc25ec7c483339d086dd538cbe091