### PR TITLE
fix: 替换条目中的中文路径链接

### DIFF
--- a/entries/系统体验与机制/Alcohol-Induced-Dissociation.md
+++ b/entries/系统体验与机制/Alcohol-Induced-Dissociation.md
@@ -31,7 +31,7 @@
 ## 相关条目
 
 - [接地（Grounding）](entries/实践与支持/Grounding.md)
-- [混合（Blending）](entries/系统角色与类型/混合.md)
+- [混合（Blending）](entries/系统角色与类型/Blending.md)
 - [解离（Dissociation）](entries/系统体验与机制/Dissociation.md)
 - [非我感（Depersonalization）](entries/系统体验与机制/Depersonalization.md)
 

--- a/entries/系统体验与机制/Family-Systems-Xianyu.md
+++ b/entries/系统体验与机制/Family-Systems-Xianyu.md
@@ -82,7 +82,7 @@
 - [单一类系统（Xianyu Theory）](entries/系统体验与机制/Single-Class-Systems-Xianyu.md)
 - [混合型系统（Xianyu Theory）](entries/系统体验与机制/Mixed-Systems-Xianyu.md)
 - [系魂型系统（Xianyu Theory）](entries/系统体验与机制/Soul-Linked-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/诊断与临床/创伤.md)
+- [创伤（Trauma）](entries/诊断与临床/Trauma.md)
 
 ---
 

--- a/entries/系统体验与机制/Mixed-Systems-Xianyu.md
+++ b/entries/系统体验与机制/Mixed-Systems-Xianyu.md
@@ -88,7 +88,7 @@
 - [单一类系统（Xianyu Theory）](entries/系统体验与机制/Single-Class-Systems-Xianyu.md)
 - [家族式系统（Xianyu Theory）](entries/系统体验与机制/Family-Systems-Xianyu.md)
 - [系魂型系统（Xianyu Theory）](entries/系统体验与机制/Soul-Linked-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/诊断与临床/创伤.md)
+- [创伤（Trauma）](entries/诊断与临床/Trauma.md)
 
 ---
 

--- a/entries/系统体验与机制/Soul-Linked-Systems-Xianyu.md
+++ b/entries/系统体验与机制/Soul-Linked-Systems-Xianyu.md
@@ -72,7 +72,7 @@
 - [单一类系统（Xianyu Theory）](entries/系统体验与机制/Single-Class-Systems-Xianyu.md)
 - [混合型系统（Xianyu Theory）](entries/系统体验与机制/Mixed-Systems-Xianyu.md)
 - [家族式系统（Xianyu Theory）](entries/系统体验与机制/Family-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/诊断与临床/创伤.md)
+- [创伤（Trauma）](entries/诊断与临床/Trauma.md)
 
 ---
 

--- a/entries/系统体验与机制/Xianyu-Theory-Niche-Classification.md
+++ b/entries/系统体验与机制/Xianyu-Theory-Niche-Classification.md
@@ -65,9 +65,9 @@
 
 ## 相关条目
 
-- [创伤（Trauma）](entries/诊断与临床/创伤.md)
-- [系统（System）](entries/系统体验与机制/系统.md)
-- [成员（Alter）](entries/系统角色与类型/成员.md)
+- [创伤（Trauma）](entries/诊断与临床/Trauma.md)
+- [系统（System）](entries/系统体验与机制/System.md)
+- [成员（Alter）](entries/系统角色与类型/Alter.md)
 - [Tulpa](entries/系统角色与类型/Tulpa.md)
 - [埃蒙加德环分类法](entries/系统体验与机制/Emongard-Ring-Classification.md)
 


### PR DESCRIPTION
## 摘要
- 调整弦羽生态位分类词条中“系统”“成员”链接，指向实际存在的 `System.md` 与 `Alter.md`
- 修正“醉酒式解离”词条中“混合”链接，改为 `entries/系统角色与类型/Blending.md`

## 动机
- 清查仓库中残留的中文路径链接，避免在站点构建时出现 404

## 风险
- 低，纯链接路径调整

## 相关条目
- entries/系统体验与机制/Xianyu-Theory-Niche-Classification.md
- entries/系统体验与机制/Alcohol-Induced-Dissociation.md

------
https://chatgpt.com/codex/tasks/task_e_68dfe50d38108333aadf0906b46d392c