### PR TITLE
feat: 优化移动端侧边栏开关

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -235,6 +235,56 @@ html, body{
   background-color: var(--c-text);
 }
 
+/* 侧边栏开关结构化样式，便于追加文字标签 */
+.sidebar-toggle__icon{
+  display: none;
+}
+
+.sidebar-toggle__label{
+  display: none;
+}
+
+@media (max-width: 768px){
+  /* 移动端改为悬浮在内容右侧的目录按钮，更易发现 */
+  .sidebar-toggle{
+    position: fixed;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 999px;
+    background: var(--c-card);
+    border: 1px solid color-mix(in oklab, var(--c-muted) 25%, transparent);
+    box-shadow: var(--shadow);
+    color: var(--c-text);
+    z-index: 120;
+  }
+
+  .sidebar-toggle__icon{
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .sidebar-toggle__icon span{
+    display: block;
+    width: 18px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+  }
+
+  .sidebar-toggle__label{
+    display: inline-block;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+  }
+}
+
 /* 封面页 */
 .cover{
   background: radial-gradient(1200px 600px at 10% 10%, color-mix(in oklab, var(--c-brand) 18%, transparent), transparent),

--- a/assets/sidebar-toggle-enhance.js
+++ b/assets/sidebar-toggle-enhance.js
@@ -1,0 +1,59 @@
+(function () {
+  "use strict";
+
+  /**
+   * 侧边栏开关增强：为按钮增加图标容器与中文标签
+   * 便于移动端用户理解该控件负责打开目录
+   */
+  function enhanceSidebarToggle(button) {
+    if (!button || button.dataset.enhanced === "1") return;
+
+    button.dataset.enhanced = "1";
+    button.setAttribute("aria-label", "切换目录");
+    button.setAttribute("title", "切换目录");
+
+    const iconWrapper = document.createElement("span");
+    iconWrapper.className = "sidebar-toggle__icon";
+
+    while (button.firstChild) {
+      iconWrapper.appendChild(button.firstChild);
+    }
+
+    const label = document.createElement("span");
+    label.className = "sidebar-toggle__label";
+    label.textContent = "目录";
+
+    button.appendChild(iconWrapper);
+    button.appendChild(label);
+  }
+
+  /**
+   * 监听按钮插入，确保 Docsify 初始化后也能完成增强
+   */
+  function observeToggle() {
+    const existing = document.querySelector(".sidebar-toggle");
+    if (existing) {
+      enhanceSidebarToggle(existing);
+      return;
+    }
+
+    const observer = new MutationObserver(function () {
+      const target = document.querySelector(".sidebar-toggle");
+      if (target) {
+        enhanceSidebarToggle(target);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", observeToggle);
+  } else {
+    observeToggle();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -239,6 +239,9 @@
     <!-- 表格响应式卡片化 -->
     <script src="./assets/table-responsive.js"></script>
 
+    <!-- 侧边栏开关强化 -->
+    <script src="./assets/sidebar-toggle-enhance.js"></script>
+
     <script>
       (function () {
         const PLACEHOLDER_ID = "__last-updated__";


### PR DESCRIPTION
## 摘要
- 为 Docsify 侧边栏开关追加结构化 DOM 与中文标签，提升移动端可理解性
- 调整移动端样式，使目录按钮悬浮于页面右侧并加入投影与文字提示

## 测试
- `npx docsify serve . -p 3000`


------
https://chatgpt.com/codex/tasks/task_e_68e02c2822988333862edfc539d6bc70