### PR TITLE
fix: 调整移动端侧边栏按钮图标样式

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -231,13 +231,27 @@ html, body{
   border-color: var(--c-divider);
   color: var(--c-text);
 }
-.sidebar-toggle span{
-  background-color: var(--c-text);
-}
 
 /* 侧边栏开关结构化样式，便于追加文字标签 */
 .sidebar-toggle__icon{
   display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar-toggle__triangle{
+  display: block;
+  width: 0;
+  height: 0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 12px solid currentColor;
+  transition: transform .2s ease;
+}
+
+/* 当侧边栏收起时，翻转图标指向内容区域 */
+body.close .sidebar-toggle__triangle{
+  transform: rotate(180deg);
 }
 
 .sidebar-toggle__label{
@@ -264,17 +278,9 @@ html, body{
   }
 
   .sidebar-toggle__icon{
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-  }
-
-  .sidebar-toggle__icon span{
-    display: block;
-    width: 18px;
-    height: 2px;
-    border-radius: 999px;
-    background: currentColor;
+    display: inline-flex;
+    width: 0;
+    height: 0;
   }
 
   .sidebar-toggle__label{

--- a/assets/sidebar-toggle-enhance.js
+++ b/assets/sidebar-toggle-enhance.js
@@ -12,12 +12,16 @@
     button.setAttribute("aria-label", "切换目录");
     button.setAttribute("title", "切换目录");
 
+    while (button.firstChild) {
+      button.removeChild(button.firstChild);
+    }
+
     const iconWrapper = document.createElement("span");
     iconWrapper.className = "sidebar-toggle__icon";
 
-    while (button.firstChild) {
-      iconWrapper.appendChild(button.firstChild);
-    }
+    const triangle = document.createElement("span");
+    triangle.className = "sidebar-toggle__triangle";
+    iconWrapper.appendChild(triangle);
 
     const label = document.createElement("span");
     label.className = "sidebar-toggle__label";


### PR DESCRIPTION
## 摘要
- 将 Docsify 目录按钮原生汉堡结构替换为自定义三角形图标，使控件语义更加贴近“展开目录”
- 调整移动端样式，新增图标翻转动画以区分展开与收起状态

## 测试
- 未执行自动化测试（前端样式调整）

------
https://chatgpt.com/codex/tasks/task_e_68e02ef2753883338bdf8d9b7cc3a5b9