### PR TITLE
feat: PDF 导出目录复用 index.md

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -49,6 +49,12 @@ markdownlint "**/*.md" --ignore "node_modules" --ignore "tools/pdf_export/vendor
 - 更新或新增词条后务必重新运行该脚本，确保索引与仓库内容一致；
 - CI 会在 PR 中执行脚本并检查 `tags.md` 是否最新。
 
+### PDF 导出目录生成逻辑
+
+- `tools/pdf_export/` 在导出 PDF 时会优先读取仓库根目录的 `index.md`，直接将其作为目录页内容；
+- 若 `index.md` 缺失或为空，则回退到按标签结构生成的默认目录；
+- 目录中的词条链接会自动重写为 PDF 内部锚点，确保离线文档中的跳转行为与线上一致。
+
 ## 相关文档
 
 - [导出 PDF 使用指南](../pdf_export/README_pdf_output.md)

--- a/tools/pdf_export/pdf_export/markdown.py
+++ b/tools/pdf_export/pdf_export/markdown.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -242,8 +243,48 @@ def build_cover_page(
     return "\n".join(lines)
 
 
-def build_directory_page(structure: CategoryStructure) -> str:
-    """根据 README/目录结构生成目录页内容。"""
+def _build_directory_from_index(anchor_lookup: Mapping[Path, str]) -> str | None:
+    """尝试以仓库根目录的 ``index.md`` 作为目录页内容。"""
+
+    index_path = PROJECT_ROOT / "index.md"
+    if not index_path.exists():
+        return None
+
+    try:
+        raw_content = index_path.read_text(encoding="utf-8")
+    except OSError as error:  # pragma: no cover - 仅在 I/O 出错时触发
+        print(f"警告: 无法读取 {index_path}: {error}", file=sys.stderr)
+        return None
+
+    stripped = raw_content.strip()
+    if not stripped:
+        return None
+
+    lines = stripped.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            lines[index] = "# 目录"
+            break
+    else:
+        lines.insert(0, "# 目录")
+        lines.insert(1, "")
+
+    directory_markdown = "\n".join(lines)
+    rewritten = rewrite_entry_links(directory_markdown, anchor_lookup).strip()
+    if not rewritten:
+        return None
+
+    return f"{rewritten}\n\n\\newpage\n"
+
+
+def build_directory_page(
+    structure: CategoryStructure, anchor_lookup: Mapping[Path, str]
+) -> str:
+    """根据 ``index.md`` 或标签结构生成目录页内容。"""
+
+    index_based = _build_directory_from_index(anchor_lookup)
+    if index_based is not None:
+        return index_based
 
     lines: list[str] = ["# 目录", ""]
 
@@ -253,7 +294,10 @@ def build_directory_page(structure: CategoryStructure) -> str:
         lines.append(f"## {category_title}")
         lines.append("")
         for document in documents:
-            anchor = build_entry_anchor(document.path)
+            anchor = anchor_lookup.get(
+                document.path.resolve(),
+                build_entry_anchor(document.path),
+            )
             lines.append(f"- [{document.title}](#{anchor})")
         lines.append("")
 
@@ -291,7 +335,7 @@ def build_combined_markdown(
         )
 
     if structure:
-        parts.append(build_directory_page(structure))
+        parts.append(build_directory_page(structure, anchor_lookup))
 
     if include_readme and README_PATH.exists():
         parts.append(README_PATH.read_text(encoding="utf-8").strip())


### PR DESCRIPTION
## 动机
- PDF 导出目录页与站点首页的条目顺序存在偏差，需要对齐 `index.md` 中的人工维护目录。

## 主要变更
- 新增基于根目录 `index.md` 生成目录页的逻辑，并在缺失时回退到原有标签结构。
- 自动重写目录中的词条链接为 PDF 内部锚点，保持离线跳转体验。
- 更新工具文档，说明目录生成策略与回退机制。

## 潜在风险
- 若 `index.md` 格式异常（例如缺乏标题或链接），可能导致目录页内容为空，虽有回退逻辑但仍需留意。

## 相关条目/链接
- `index.md`
- `docs/tools/README.md`
- `tools/pdf_export/pdf_export/markdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68e048dd96a483338ff475b775f9c4c2