### PR TITLE
feat: regenerate tags and maintain '相关条目' sections (batch)

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -14,6 +14,7 @@
 | `tools/gen_changelog_by_tags.py` | 按 Git 标签时间顺序生成 `changelog.md`，并按 Conventional Commits 类型分组                         | `python tools/gen_changelog_by_tags.py --output changelog.md`，可搭配 `--latest-only` 或 `--latest-to-head` |
 | `tools/pdf_export/`              | Pandoc 驱动的整站 PDF 导出工具，支持封面、目录、忽略列表与中文字体配置                                          | `python tools/pdf_export/export_to_pdf.py` 或 `python -m pdf_export`                                    |
 | `tools/gen-validation-report.py` | 读取《CONTRIBUTING.md》与《docs/TEMPLATE_ENTRY.md》，校验词条结构并生成 `docs/VALIDATION_REPORT.md` | `python tools/gen-validation-report.py`                                                                |
+| `tools/retag_and_related.py`     | 批量重建词条 Frontmatter 标签并生成“相关条目”区块，支持干跑、范围过滤等参数               | `python tools/retag_and_related.py`、`python tools/retag_and_related.py --dry-run --limit 5`             |
 | `generate_tags_index.py`         | 扫描 `entries/` Frontmatter，生成 `tags.md` 标签索引                                             | `python generate_tags_index.py`                                                                       |
 
 如需新增脚本，请保持功能说明与示例用法同步更新本章节，方便贡献者快速定位维护工具。

--- a/entries/Adaptive.md
+++ b/entries/Adaptive.md
@@ -1,6 +1,6 @@
 ---
 title: 适应型（Adaptive）
-tags: [系统角色与类型]
+tags: [创伤, 系统角色与类型, 适应型, 诊断与临床, 防御机制, 自我照护, 系统体验与机制, 分类与对比]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 - [解离性身份障碍（DID）](entries/DID.md)
 - [其他特定解离性障碍（OSDD）](entries/OSDD.md)
 - [创伤（Trauma）](entries/Trauma.md)
+
+## 相关条目
+
+- [自发型（Spontaneous）](/entries/Spontaneous.md)
+- [成员（Alter）](/entries/Alter.md)
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [创伤（Trauma）](/entries/Trauma.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)

--- a/entries/Admin.md
+++ b/entries/Admin.md
@@ -1,6 +1,6 @@
 ---
 title: 管理者（Admin）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 管理者, 沟通协作, 风险应对, 记忆管理, 系统管理, 社区文化, 内部自助者]
 updated: 2025-10-03
 ---
 
@@ -41,11 +41,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [守门人（Gatekeeper）](entries/Gatekeeper.md)
-- [内部自助者（ISH）](entries/Internal-Self-Helper-ISH.md)
-- [权限（Permissions）](entries/Permissions.md)
-- [伪主体（Fauxmain）](entries/Fauxmain.md)
-
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [成员（Alter）](/entries/Alter.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [混合（Blending）](/entries/Blending.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [守门人（Gatekeeper）](/entries/Gatekeeper.md)
 ## 参考与延伸阅读
 
 Wikipedia contributors. (2024, January). *Alter (dissociative identity disorder)*. In Wikipedia, The Free Encyclopedia. [https://en.wikipedia.org/wiki/Alter_(dissociative_identity_disorder](https://en.wikipedia.org/wiki/Alter_(dissociative_identity_disorder))

--- a/entries/Alcohol-Induced-Dissociation.md
+++ b/entries/Alcohol-Induced-Dissociation.md
@@ -1,6 +1,6 @@
 ---
 title: 醉酒解离（Alcohol-Induced Dissociation）
-tags: [系统体验与机制]
+tags: [解离, 醉酒解离, 躯体化, 物质影响, 沟通协作, 感知体验, 应对策略, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -36,11 +36,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [接地（Grounding）](entries/Grounding.md)
-- [混合（Blending）](entries/Blending.md)
-- [解离（Dissociation）](entries/Dissociation.md)
-- [非我感（Depersonalization）](entries/Depersonalization.md)
-
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [功能性分离（Functional Dissociation）](/entries/Functional-Dissociation.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [成员（Alter）](/entries/Alter.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [病理性解离（Pathological Dissociation）](/entries/Pathological-Dissociation.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
 ## 参考资料
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Alexithymia.md
+++ b/entries/Alexithymia.md
@@ -1,6 +1,6 @@
 ---
 title: 述情障碍（Alexithymia）
-tags: [诊断与临床]
+tags: [述情障碍, 情感难言症, 情感表达不能, 概念演化, 防御机制, 躯体化, 诊断与临床, 自闭症谱系]
 updated: 2025-10-03
 ---
 
@@ -76,9 +76,14 @@ DSM-5-TR 在躯体症状障碍、创伤后应激障碍、进食障碍等章节�
 
 ## 相关条目
 
-- [情绪觉察练习（Emotion Awareness Practice）](entries/Emotion-Awareness-Practice.md)
-- [多伦多述情障碍量表（Toronto Alexithymia Scale）](entries/Toronto-Alexithymia-Scale.md)
-
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
 ## 参考与延伸阅读
 
 [^述情障碍-apa]: American Psychiatric Association. (2013). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). Washington, DC.

--- a/entries/Alter.md
+++ b/entries/Alter.md
@@ -1,6 +1,6 @@
 ---
 title: 成员（Alter）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 沟通协作, 系统体验与机制, 诊断与临床, 成员, 社区文化, 内部界限, 基础概念]
 updated: 2025-10-03
 ---
 
@@ -28,8 +28,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- 参见：[系统（System）](entries/System.md)、[宿主（Host）](entries/Host.md)、[管理者（Admin）](entries/Admin.md)、[共前台（Co-fronting）](entries/Co-Fronting.md)
-
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [权限（Permissions）](/entries/Permissions.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-alter]: Pluralpedia. (2024). [Alter](https://pluralpedia.org/w/Alter).

--- a/entries/Alterhuman.md
+++ b/entries/Alterhuman.md
@@ -1,6 +1,6 @@
 ---
 title: 特殊认同（Alterhuman）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 身份认同, 风险应对, 自我照护, 社会文化, 沟通策略, 基础概念, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [系魂（Soulbond）](entries/Soulbond.md)
-- [人格面具（Persona）](entries/Persona.md)
-- [碎片（Fragment）](entries/Fragment.md)
-
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [成员（Alter）](/entries/Alter.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [自发型（Spontaneous）](/entries/Spontaneous.md)
+- [主体（Main）](/entries/Main.md)
+- [碎片（Fragment）](/entries/Fragment.md)
 ## 参考与延伸阅读
 
 [^alterhuman-wiki]: Alterhuman Wiki. 2022. “Alterhuman.” [https://alterhuman.org/wiki/alterhuman.](https://alterhuman.org/wiki/alterhuman.)

--- a/entries/Another-Me-DID-Depictions.md
+++ b/entries/Another-Me-DID-Depictions.md
@@ -1,6 +1,6 @@
 ---
 title: 《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）
-tags: [虚拟角色与文学影视作品]
+tags: [解离性身份障碍 DID, 治疗支持, 媒体呈现, 叙事结构, 身份认同, 基础概念, 双重人格, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
 - [创伤（Trauma）](entries/Trauma.md)
 
+## 相关条目
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](/entries/Fight-Club-1999-Identity-Metaphor.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Anxiety.md
+++ b/entries/Anxiety.md
@@ -1,6 +1,6 @@
 ---
 title: 焦虑（Anxiety）
-tags: [诊断与临床]
+tags: [焦虑, 躯体反应, 认知与情绪, 行为变化, 基础概念, 鉴别诊断, 诊断要点, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -73,9 +73,14 @@ DSM-5-TR 要求症状在多种情境中持续至少 6 个月，伴随不安、�
 
 ## 相关条目
 
-- [惊恐发作（Panic Attack）](entries/Panic-Attack.md)
-- [安全计划（Safety Plan）](entries/Safety-Plan.md)
-
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
 ## 参考与延伸阅读
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Apparently-Normal-Part-Emotional-Part-Model.md
+++ b/entries/Apparently-Normal-Part-Emotional-Part-Model.md
@@ -1,6 +1,6 @@
 ---
 title: ANP-EP 模型（Apparently Normal Part–Emotional Part Model）
-tags: [系统体验与机制]
+tags: [解离性身份障碍 DID, 其他特定解离性障碍 OSDD, 理论模型, 诊断与临床, 结构性解离, 社区文化, 核心特征, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -102,6 +102,16 @@ updated: 2025-10-03
 
 ---
 
+## 相关条目
+
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [成员（Alter）](/entries/Alter.md)
+- [自动驾驶（Autopilot）](/entries/Autopilot.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](/entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
 ## 参考文献
 
 [^ANP-1]: Van der Hart, O., Nijenhuis, E. R. S., & Steele, K. (2006). *The Haunted Self: Structural Dissociation and the Treatment of Chronic Traumatization*. W. W. Norton.

--- a/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md
+++ b/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md
@@ -1,6 +1,6 @@
 ---
 title: 注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）
-tags: [诊断与临床]
+tags: [注意力缺陷多动障碍 ADHD, 行为特征, 行为与心理干预, 药物治疗, 注意力不足, 教育支持, 功能评估, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -73,10 +73,14 @@ ADHD 在儿童中的盛行率约 5% 左右，成人约 2%–3%，多数个体的
 
 ## 相关条目
 
-- [执行功能（Executive Function）](entries/Executive-Function.md)
-- [结构化日程（Structured Schedule）](entries/Structured-Schedule.md)
-- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
-
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [躁狂（Mania）](/entries/Mania.md)
 ## 参考与延伸阅读
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Autism-Spectrum-Disorder.md
+++ b/entries/Autism-Spectrum-Disorder.md
@@ -1,6 +1,6 @@
 ---
 title: 孤独症谱系（Autism Spectrum Disorder）
-tags: [诊断与临床]
+tags: [孤独症谱系, 社会交流, 早期干预, 教育与环境调适, 成年阶段, 感觉差异, 局限兴趣与行为, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -71,9 +71,14 @@ DSM-5-TR 要求在社会交流互动与局限重复行为两个维度满足具�
 
 ## 相关条目
 
-- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
-- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
-
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [焦虑（Anxiety）](/entries/Anxiety.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
 ## 参考与延伸阅读
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Autopilot.md
+++ b/entries/Autopilot.md
@@ -1,6 +1,6 @@
 ---
 title: 自动驾驶（Autopilot）
-tags: [系统体验与机制]
+tags: [解离性身份障碍 DID, 自动驾驶, 记忆差异, 触发与过载, 行为持续但意识缺席, 自我感强度, 系统内空窗, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -42,11 +42,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [解离](entries/Dissociation.md)
-- [应激反应](entries/Stress-Response.md)
-- [整合](entries/Integration.md)
-- [意识共存](entries/Co-Consciousness.md)
-
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [系统（System）](/entries/System.md)
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](/entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [迭代（Iteration）](/entries/Iteration.md)
+- [躯体认同（Body Ownership）](/entries/Body-Ownership.md)
 ## 参考资料
 
 [^自动驾驶-1]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision*. [https://www.isst-d.org/wp-content/uploads/2019/02/ISSTD-Guidelines-Adult-DID-Treatment-2011.pdf](https://www.isst-d.org/wp-content/uploads/2019/02/ISSTD-Guidelines-Adult-DID-Treatment-2011.pdf)

--- a/entries/Back-Being-Back.md
+++ b/entries/Back-Being-Back.md
@@ -1,6 +1,6 @@
 ---
 title: 后台（Back / Being Back）
-tags: [系统体验与机制]
+tags: [后台, 状态转换, 功能分配, 风险应对, 边界管理, 社群经验, 沟通协作, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -28,8 +28,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- 参见：[前台（Front / Fronting）](entries/Front-Fronting.md)、[共前台（Co-fronting）](entries/Co-Fronting.md)、[内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)、[切换（Switch）](entries/Switch.md)
-
+- [成员（Alter）](/entries/Alter.md)
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [外投射（External Projection）](/entries/External-Projection.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-back]: Pluralpedia. (2024). [Back](https://pluralpedia.org/w/Back).

--- a/entries/Bias.md
+++ b/entries/Bias.md
@@ -1,6 +1,6 @@
 ---
 title: 偏重（Bias / Median）
-tags: [系统体验与机制]
+tags: [偏重, 主要特征, 诊断与临床, 社群语境, 常见误区, 实务建议, 系统体验与机制, 与其他概念的比较]
 updated: 2025-10-03
 ---
 
@@ -72,6 +72,16 @@ Median 体验、半多意识体、半分离系统
 
 ---
 
+## 相关条目
+
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [冥想（Meditation）](/entries/Meditation.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [接地（Grounding）](/entries/Grounding.md)
+- [超级破碎（Polyfragmented）](/entries/Polyfragmented.md)
 ## 参考资料
 
 [^偏重-1]: The Plural Association. (2020). *Median plurality: Experiences between singlet and multiple*. [https://www.thepluralassociation.org/](https://www.thepluralassociation.org/)

--- a/entries/Bipolar-Disorders.md
+++ b/entries/Bipolar-Disorders.md
@@ -1,6 +1,6 @@
 ---
 title: 双相障碍（Bipolar Disorders）
-tags: [诊断与临床]
+tags: [双相障碍, 躁狂 轻躁狂期, 混合特征, 抑郁期, 功能影响, 基础概念, 鉴别诊断, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -76,9 +76,14 @@ DSM-5-TR 强调发作次数与症状数量阈值，ICD-11 则聚焦发作时段�
 
 ## 相关条目
 
-- [躁狂（Mania）](entries/Mania.md)
-- [情绪稳定策略（Mood Stabilization Strategies）](entries/Mood-Stabilization-Strategies.md)
-
+- [焦虑（Anxiety）](/entries/Anxiety.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
 ## 参考与延伸阅读
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Blending.md
+++ b/entries/Blending.md
@@ -1,6 +1,6 @@
 ---
 title: 混合（Blending）
-tags: [系统角色与类型]
+tags: [解离性身份障碍 DID, 系统角色与类型, 混合, 阶段化治疗, 身份感与时间感模糊, 环境熟悉度, 情绪与记忆激活, 安全地探索混合]
 updated: 2025-10-03
 ---
 
@@ -28,6 +28,16 @@ updated: 2025-10-03
 - **共识式工作协议**：在系统内部建立共享日志、情绪评级或轮换安排，有助于在混合出现时快速分辨当下的主导成员、需求与界限。[^brand2013]
 - **安全地探索混合**：治疗关系中的支持性环境可以让系统成员以观察者身份体验混合，从而提炼功能互补的优势，同时避免在高波动阶段贸然追求“永久融合”。[^loewenstein1991][^brand2014]
 
+## 相关条目
+
+- [管理者（Admin）](/entries/Admin.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [其他特定解离性障碍（OSDD）](/entries/OSDD.md)
+- [整合（Integration）](/entries/Integration.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
 ## 参考资料
 
 [^loewenstein1991]: Loewenstein, R. J. (1991). An Office Mental Status Examination for Complex Chronic Dissociative Symptoms and Multiple Personality Disorder. _Psychiatric Clinics of North America, 14_(3), 567–604. [https://doi.org/10.1016/S0193-953X(18](https://doi.org/10.1016/S0193-953X(18))30290-9

--- a/entries/Body-Ownership.md
+++ b/entries/Body-Ownership.md
@@ -1,6 +1,6 @@
 ---
 title: 躯体认同（Body Ownership）
-tags: [系统体验与机制]
+tags: [躯体认同, 阶段性认同, 身体创伤与身体异化, 共享身体 缺乏共识, 与迭代 重构等系统变化, 与性别 年龄表达, 核心构成要素, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -36,6 +36,16 @@ updated: 2025-10-03
 3. **协商使用规则**：明确身体使用时段、护理责任与界限（如外表改造、纹身、医疗决策），减少“被剥夺”或“被侵占”的感受。
 4. **寻求社群与专业支持**：多意识体互助社群、具解离经验的治疗师与知情友人能提供肯定与见证，缓解外界误解对躯体认同造成的冲击。
 
+## 相关条目
+
+- [融合（Fusion）](/entries/Fusion.md)
+- [迭代（Iteration）](/entries/Iteration.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
 ## 参考资料
 
 - American Psychiatric Association. *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). Washington, DC: APA Publishing, 2013.

--- a/entries/Borderline-Personality-Disorder-BPD.md
+++ b/entries/Borderline-Personality-Disorder-BPD.md
@@ -1,6 +1,6 @@
 ---
 title: 边缘性人格障碍（Borderline Personality Disorder，BPD）
-tags: [诊断与临床]
+tags: [边缘性人格障碍, BPD, 认知体验, 解离性障碍, 药物治疗, 自恋或表演型人格障碍, 技能训练, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -75,10 +75,14 @@ BPD 终身患病率约 1%–2%，女性就医比例较高。多数人在长期�
 
 ## 相关条目
 
-- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-- [解离性身份障碍（DID）](entries/DID.md)
-- [情绪调节技能（Emotion Regulation Skills）](entries/Emotion-Regulation-Skills.md)
-
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](/entries/Narcissistic-Personality-Disorder-NPD.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [躁狂（Mania）](/entries/Mania.md)
 ## 参考与延伸阅读
 
 [^apa]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.).

--- a/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md
+++ b/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md
@@ -1,6 +1,6 @@
 ---
 title: 《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）
-tags: [虚拟角色与文学影视作品]
+tags: [解离性身份障碍 DID, 不可饶恕的她 对多重人格的叙事化呈现, 身份反转, 治疗与支持, 创伤触发, 基础概念, 主要解离元素, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -26,6 +26,16 @@ updated: 2025-10-03
 - [解离性身份障碍（DID）](entries/DID.md)
 - [触发（Trigger）](entries/Trigger.md)
 
+## 相关条目
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](/entries/Fight-Club-1999-Identity-Metaphor.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/CPTSD.md
+++ b/entries/CPTSD.md
@@ -1,6 +1,6 @@
 ---
 title: 复杂性创伤后应激障碍（CPTSD）
-tags: [诊断与临床]
+tags: [创伤后应激障碍 PTSD, 来源, 复杂性创伤后应激障碍, CPTSD, 阶段化创伤治疗, 重度抑郁或双相障碍, 边缘性人格障碍, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -107,14 +107,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [创伤后应激障碍](entries/PTSD.md)
-- [创伤](entries/Trauma.md)
-- [解离性身份障碍](entries/DID.md)
-- [解离性遗忘](entries/Dissociative-Amnesia-DA.md)
-- [人格解体/现实解体障碍](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-
----
-
+- [闪回（Flashback）](/entries/Flashback.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
 ## 参考与延伸阅读
 
 1. World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Complex post traumatic stress disorder (6B41).* 检索于 2025-01-05，来自 [https://icd.who.int](https://icd.who.int)。[^who2023]

--- a/entries/Caregiver.md
+++ b/entries/Caregiver.md
@@ -1,6 +1,6 @@
 ---
 title: 照顾者（Caregiver）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 照顾者, 情感调节能力, 跨系统互助, 界限设定, 日常照护, 内部养育者, 常见特征]
 updated: 2025-10-03
 ---
 
@@ -42,3 +42,14 @@ updated: 2025-10-03
 [^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+
+## 相关条目
+
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Co-Consciousness.md
+++ b/entries/Co-Consciousness.md
@@ -1,6 +1,6 @@
 ---
 title: 意识共存（Co-consciousness）
-tags: [系统体验与机制]
+tags: [意识共存, 多轨思维, 预设沟通渠道, 融合 整合, 情绪共鸣, 安全退出机制, 系统体验与机制, 存在感]
 updated: 2025-10-03
 ---
 
@@ -42,6 +42,16 @@ updated: 2025-10-03
 
 临床研究指出，意识共存是解离性身份障碍中常见的合作形式，也是迈向功能整合的重要指标之一。能否稳定维持共存，与内部安全感、信任与外部支持密切相关[^意识共存-1][^意识共存-2]。
 
+## 相关条目
+
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
 ## 参考资料
 
 [^意识共存-1]: Kluft, R. P. (1984). Treatment of multiple personality disorder. *Psychiatric Clinics of North America, 7*(1), 9-29.

--- a/entries/Co-Fronting.md
+++ b/entries/Co-Fronting.md
@@ -1,6 +1,6 @@
 ---
 title: 共前台（Co-fronting）
-tags: [系统体验与机制]
+tags: [定义与同义词, 共前台, 部分社群用法, 主要特征, 社群与临床语境, 常见误区, 系统体验与机制, 实务建议]
 updated: 2025-10-03
 ---
 
@@ -43,10 +43,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [前台（Front / Fronting）](entries/Front-Fronting.md)
-* [切换（Switch）](entries/Switch.md)
-* [混合（Blending）](entries/Blending.md)
-
+- [切换（Switch）](/entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-cofront]: Pluralpedia. (2024). [Co-fronting](https://pluralpedia.org/w/Co-fronting).

--- a/entries/Consciousness-Modification.md
+++ b/entries/Consciousness-Modification.md
@@ -1,6 +1,6 @@
 ---
 title: 意识修改（Consciousness Modification）
-tags: [系统体验与机制]
+tags: [意识修改, 技能强化, 角色替换, 渐进训练, 情绪调节, 外部支持, 系统体验与机制, 内部协商]
 updated: 2025-10-03
 ---
 
@@ -40,6 +40,16 @@ updated: 2025-10-03
 3. 在安全的内景或外部仪式中进行，搭配接地与稳定化措施。
 4. 事后回顾影响，记录正面与负面结果，并安排后续关怀。
 
+## 相关条目
+
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [非我感（Depersonalization）](/entries/Depersonalization.md)
 ## 参考资料
 
 [^意识修改-1]: Dell, P. F., & O'Neil, J. A. (Eds.). (2009). *Dissociation and the Dissociative Disorders: DSM-V and Beyond*. Routledge.

--- a/entries/Core.md
+++ b/entries/Core.md
@@ -1,6 +1,6 @@
 ---
 title: 核心（Core）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 核心, 与碎片的关系, 身份协商, 谱系中间者视角, 核心迁移, 成长空间, 安全提示]
 updated: 2025-10-03
 ---
 
@@ -41,11 +41,14 @@ _本词条包含需要及时更新的即时内容或含有目前仍不能确定�
 
 ## 相关条目
 
-- [碎片（Fragment）](entries/Fragment.md)
-- [主体（Main）](entries/Main.md)
-- [伪主体（Fauxmain）](entries/Fauxmain.md)
-- [管理者（Admin）](entries/Admin.md)
-
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
+- [守门人（Gatekeeper）](/entries/Gatekeeper.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [主体（Main）](/entries/Main.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [成员（Alter）](/entries/Alter.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-core]: Pluralpedia. 2023. “Core.” [https://pluralpedia.org/w/Core.](https://pluralpedia.org/w/Core.)

--- a/entries/DID.md
+++ b/entries/DID.md
@@ -1,6 +1,6 @@
 ---
 title: 解离性身份障碍（Dissociative Identity Disorder，DID）
-tags: [诊断与临床]
+tags: [解离, 解离性身份障碍 DID, 解离性身份障碍, 躯体与情绪症状, 身份切换, 记忆断片, 部分解离性身份障碍, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -110,14 +110,14 @@ DID 的治疗通常遵循分阶段模式：
 
 ## 相关条目
 
-- [部分解离性身份障碍（PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
-- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
-- [创伤后应激障碍（PTSD）](entries/PTSD.md)
-- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-- [人格解体/现实解体障碍（DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-
----
-
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](/entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+- [其他特定解离性障碍（OSDD）](/entries/OSDD.md)
+- [病理性解离（Pathological Dissociation）](/entries/Pathological-Dissociation.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](/entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
 ## 参考与延伸阅读
 
 1. World Health Organization. (2019). *ICD-11 for Mortality and Morbidity Statistics*.

--- a/entries/Delirium.md
+++ b/entries/Delirium.md
@@ -1,6 +1,6 @@
 ---
 title: 谵妄（Delirium）
-tags: [诊断与临床]
+tags: [系统体验, 来源, 谵妄, 非药物干预, 重度抑郁或双相障碍发作, 解离性发作 离解症, 药物策略, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -101,13 +101,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [定向障碍](entries/Disorientation.md)
-- [创伤](entries/Trauma.md)
-- [复杂性创伤后应激障碍](entries/CPTSD.md)
-- [人格解体/现实解体障碍](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-
----
-
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
+- [焦虑（Anxiety）](/entries/Anxiety.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [闪回（Flashback）](/entries/Flashback.md)
 ## 参考与延伸阅读
 
 1. World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Delirium (6D70).* 检索于 2025-01-05，来自 [https://icd.who.int](https://icd.who.int)。[^who2023]

--- a/entries/Depersonalization-Derealization-Disorder-DPDR.md
+++ b/entries/Depersonalization-Derealization-Disorder-DPDR.md
@@ -1,6 +1,6 @@
 ---
 title: 人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）
-tags: [诊断与临床]
+tags: [来源, 人格解体 现实解体障碍, DPDR, 重度抑郁障碍或双相障碍, 身体与感官练习, 药物治疗, 自我监控过度, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -107,14 +107,14 @@ _仅供参考，**不能**替代专业医师的诊断和治疗方案。如果有
 
 ## 相关条目
 
-- [解离](entries/Dissociation.md)
-- [非我感](entries/Depersonalization.md)
-- [创伤后应激障碍](entries/PTSD.md)
-- [复杂性创伤后应激障碍](entries/CPTSD.md)
-- [解离性身份障碍](entries/DID.md)
-
----
-
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
 ## 参考与延伸阅读
 
 1. World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Depersonalization-derealization disorder (6B65).* 检索于 2025-01-05，来自 [https://icd.who.int](https://icd.who.int)。[^who2023dp]

--- a/entries/Depersonalization.md
+++ b/entries/Depersonalization.md
@@ -1,6 +1,6 @@
 ---
 title: 非我感（Depersonalization）
-tags: [系统体验与机制]
+tags: [非我感, 记录触发因素, 持续性差异, 情绪与感官的分离, 必要时寻求专业支持, 建立内部共识, 系统体验与机制, 地面化练习]
 updated: 2025-10-03
 ---
 
@@ -39,6 +39,16 @@ Not-me 感、他者感、身份异化感 感知区分 感知壁垒
 - **建立内部共识**：邀请拥有强烈非我感的成员在安全空间里表达需求，并讨论如何共享控制权，能减少突发冲突。
 - **必要时寻求专业支持**：若非我感伴随情绪麻木、严重功能受损，可考虑熟悉解离与多重意识经验的治疗者进行评估。
 
+## 相关条目
+
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
 ## 参考资料
 
 [^非我感-1]: Sierra, M., & Berrios, G. E. (1997). Depersonalization: Neurobiological perspectives. *Biological Psychiatry, 42*(9), 898-908.

--- a/entries/Depressive-Disorders.md
+++ b/entries/Depressive-Disorders.md
@@ -1,6 +1,6 @@
 ---
 title: 抑郁障碍（Depressive Disorders）
-tags: [诊断与临床]
+tags: [来源, 抑郁障碍, 躯体疾病, 认知与社会因素, 药物治疗, 药物或物质影响, 综合策略, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -101,14 +101,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [重度抑郁障碍](entries/Major-Depressive-Disorder-MDD.md)
-- [双相障碍](entries/Bipolar-Disorder-BD.md)
-- [创伤后应激障碍](entries/PTSD.md)
-- [焦虑障碍](entries/Anxiety-Disorders.md)
-- [复杂性创伤后应激障碍](entries/CPTSD.md)
-
----
-
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
 ## 参考与延伸阅读
 
 1. World Health Organization. (2023). *ICD-11 for Mortality and Morbidity Statistics: Depressive episode and recurrent depressive disorder.* 检索于 2025-01-05，来自 [https://icd.who.int](https://icd.who.int)。[^who2023dep]

--- a/entries/Disorientation.md
+++ b/entries/Disorientation.md
@@ -1,6 +1,6 @@
 ---
 title: 定向障碍（Disorientation）
-tags: [诊断与临床]
+tags: [来源, 定向障碍, 自我定向障碍, 结构性解离视角, 精神病性障碍, 神经退行性疾病, 神经生物学, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -106,11 +106,14 @@ ICD-11 与 DSM-5-TR 均将定向障碍视为谵妄的重要表现，但 ICD-11 �
 
 ## 相关条目
 
-- [谵妄（Delirium）](entries/Delirium.md)
-- [创伤（Trauma）](entries/Trauma.md)
-- [创伤后应激障碍（PTSD）](entries/PTSD.md)
-- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [闪回（Flashback）](/entries/Flashback.md)
+- [焦虑（Anxiety）](/entries/Anxiety.md)
 ## 参考与延伸阅读
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Dissociation.md
+++ b/entries/Dissociation.md
@@ -1,6 +1,6 @@
 ---
 title: 解离（Dissociation）
-tags: [系统体验与机制]
+tags: [解离, 解离性身份障碍 DID, 其他特定解离性障碍 OSDD, 参见, 系统体验与机制, 用于区分不同语境下的, 本词条为消歧义页面, DPDR]
 updated: 2025-10-03
 ---
 
@@ -16,3 +16,14 @@ updated: 2025-10-03
 - [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
 - [其他特定解离性障碍（Other Specified Dissociative Disorder，OSDD）](entries/OSDD.md)
 - [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+
+## 相关条目
+
+- [功能性分离（Functional Dissociation）](/entries/Functional-Dissociation.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [病理性解离（Pathological Dissociation）](/entries/Pathological-Dissociation.md)
+- [其他特定解离性障碍（OSDD）](/entries/OSDD.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](/entries/Fight-Club-1999-Identity-Metaphor.md)

--- a/entries/Dissociative-Amnesia-DA.md
+++ b/entries/Dissociative-Amnesia-DA.md
@@ -1,6 +1,6 @@
 ---
 title: 解离性遗忘（Dissociative Amnesia，DA）
-tags: [诊断与临床]
+tags: [来源, 解离性遗忘, 风险评估, 风险因素, 阶段化治疗, 遗忘模式, 诊断与临床, 解离性漫游]
 updated: 2025-10-03
 ---
 
@@ -121,12 +121,14 @@ D. 症状不能被分离性身份障碍、创伤后应激障碍、急性应激�
 
 ## 相关条目
 
-- [创伤](entries/Trauma.md)
-- [创伤后应激障碍](entries/PTSD.md)
-- [复杂性创伤后应激障碍](entries/CPTSD.md)
-- [解离性身份障碍](entries/DID.md)
-- [人格解体/现实解体障碍](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [闪回（Flashback）](/entries/Flashback.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
 ## 参考与延伸阅读
 
 [^dsm5]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Dostoevsky-The-Double-Self-Division.md
+++ b/entries/Dostoevsky-The-Double-Self-Division.md
@@ -1,6 +1,6 @@
 ---
 title: 陀思妥耶夫斯基《双重人格》（The Double）与自我分裂
-tags: [虚拟角色与文学影视作品]
+tags: [陀思妥耶夫斯基 双重人格, 媒体呈现, 镜像对手, 语言与叙事, 社会疏离, 核心意象, 基础概念, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [身份解体（Dissociation）](entries/Dissociation.md)
 - [人格面具（Persona）](entries/Persona.md)
 
+## 相关条目
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Emmengard-Classification.md
+++ b/entries/Emmengard-Classification.md
@@ -1,6 +1,6 @@
 ---
 title: 埃蒙加德分类法（Emmengard Classification）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 埃蒙加德分类法, 无等级结构, 多维度组合, 主观与流动性, 基础概念, 使用原则, 实践建议]
 updated: 2025-10-03
 ---
 
@@ -40,11 +40,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [适应型（Adaptive）](entries/Adaptive.md)
-- [自发型（Spontaneous）](entries/Spontaneous.md)
-- [图帕（Tulpa）](entries/Tulpa.md)
-- [系魂（Soulbond）](entries/Soulbond.md)
-
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [自发型（Spontaneous）](/entries/Spontaneous.md)
 ## 实践建议
 
 - 记录系统历史、重要事件与成员加入时间，便于回顾标签适配性。

--- a/entries/Exomemory.md
+++ b/entries/Exomemory.md
@@ -1,6 +1,6 @@
 ---
 title: 独有记忆（Exomemory）
-tags: [系统体验与机制]
+tags: [独有记忆, 现象特征, 记忆建构理论, 记录方式, 系统协商, 潜在功能, 系统体验与机制, 治疗协作]
 updated: 2025-10-03
 ---
 
@@ -31,10 +31,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
-- [独立性（Independence）](entries/Independence.md)
-- [系魂（Soulbond）](entries/Soulbond.md)
-
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [意识共存（Co-consciousness）](/entries/Co-Consciousness.md)
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [独立性（Independence）](/entries/Independence.md)
 ## 参考与延伸阅读
 
 [^lifton2021]: Lifton, P. 2021. “Imaginal Worlds and Autonomous Identity Narratives in Plural Communities.” *Plurality Studies Review* 2(1): 45–63.

--- a/entries/External-Projection.md
+++ b/entries/External-Projection.md
@@ -1,6 +1,6 @@
 ---
 title: 外投射（External Projection）
-tags: [系统体验与机制]
+tags: [外投射, 投射方向, 边界设定, 环境评估, 沟通习惯, 功能性, 与幻觉的区分, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -28,10 +28,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
-- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
-- [偏重（Bias）](entries/Bias.md)
-
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)
+- [成员（Alter）](/entries/Alter.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [投影（Projection）](/entries/Projection.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
 ## 参考与延伸阅读
 
 [^projection-pluralpedia]: Pluralpedia. (n.d.). [Projection](https://pluralpedia.org/w/Projection).

--- a/entries/Family-Systems-Xianyu.md
+++ b/entries/Family-Systems-Xianyu.md
@@ -1,6 +1,6 @@
 ---
 title: 家族式系统（Family Systems, Xianyu Theory）
-tags: [系统体验与机制]
+tags: [特征, 定义与同义词, 功能定位, 家族化系统, 家庭型系统, 亲属式系统, 系统体验与机制, 家族式系统]
 updated: 2025-10-03
 ---
 
@@ -84,14 +84,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [弦羽理论生态位分类法](entries/Xianyu-Theory-Niche-Classification.md)
-- [单一类系统（Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
-- [混合型系统（Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
-- [系魂型系统（Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/Trauma.md)
-
----
-
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](/entries/Mixed-Systems-Xianyu.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)
 ## 参考与来源
 
 - 原文：弦羽系统提出的《弦羽理论生态位分类法》手稿

--- a/entries/Fauxmain.md
+++ b/entries/Fauxmain.md
@@ -1,6 +1,6 @@
 ---
 title: 伪主体（Fauxmain）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 伪主体, 角色特征, 风险应对, 身份定位, 沟通策略, 形成原因, 外部认知差异]
 updated: 2025-10-03
 ---
 
@@ -26,10 +26,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [主体（Main）](entries/Main.md)
-- [宿主（Host）](entries/Host.md)
-- [混合（Blending）](entries/Blending.md)
-
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [主体（Main）](/entries/Main.md)
+- [核心（Core）](/entries/Core.md)
+- [管理者（Admin）](/entries/Admin.md)
 ## 参考与延伸阅读
 
 [^fauxmain-pluralpedia]: Pluralpedia. 2023. “Fauxmain.” [https://pluralpedia.org/w/Fauxmain.](https://pluralpedia.org/w/Fauxmain.)

--- a/entries/Fight-Club-1999-Identity-Metaphor.md
+++ b/entries/Fight-Club-1999-Identity-Metaphor.md
@@ -1,6 +1,6 @@
 ---
 title: 《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻
-tags: [虚拟角色与文学影视作品]
+tags: [解离性身份障碍 DID, 搏击俱乐部, 1999, 资本主义批判, 自我对峙, 人格镜像, 解体与重构主题, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [融合（Fusion）](entries/Fusion.md)
 - [非我感（Depersonalization）](entries/Depersonalization.md)
 
+## 相关条目
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Flashback.md
+++ b/entries/Flashback.md
@@ -1,6 +1,6 @@
 ---
 title: 闪回（Flashback）
-tags: [诊断与临床]
+tags: [创伤后应激障碍 PTSD, 定义与同义词, 来源, 闪回, 重要说明, 误区3, 诊断与临床, 误区2]
 updated: 2025-10-03
 ---
 
@@ -119,14 +119,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [创伤后应激障碍（PTSD）](entries/PTSD.md)
-- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-- [解离（Dissociation）](entries/Dissociation.md)
-- [侵入性思维](entries/Intrusive-Thoughts.md)
-- [创伤](entries/Trauma.md)
-
----
-
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [创伤（Trauma）](/entries/Trauma.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](/entries/Dissociative-Amnesia-DA.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [定向障碍（Disorientation）](/entries/Disorientation.md)
+- [谵妄（Delirium）](/entries/Delirium.md)
 ## 参考与延伸阅读
 
 [apa2022]: American Psychiatric Association. (2022). _DSM-5-TR: Diagnostic and Statistical Manual of Mental Disorders_.

--- a/entries/Fragment.md
+++ b/entries/Fragment.md
@@ -1,6 +1,6 @@
 ---
 title: 碎片（Fragment）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 碎片, 与完整成员的区别, 风险应对, 识别方法, 结构性解离模型, 系统影响, 神经生物学视角]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [解离（Dissociation）](entries/Dissociation.md)
-- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
-- [融合（Fusion）](entries/Fusion.md)
-
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [主体（Main）](/entries/Main.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-fragment]: Pluralpedia. 2022. “Fragment.” [https://pluralpedia.org/w/Fragment.](https://pluralpedia.org/w/Fragment.)

--- a/entries/Front-Fronting.md
+++ b/entries/Front-Fronting.md
@@ -1,6 +1,6 @@
 ---
 title: 前台（Front / Fronting）
-tags: [系统体验与机制]
+tags: [前台, 时间敏感性, 控制权, 记录工具, 社区文化, 术语差异, 外界沟通, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -28,8 +28,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- 参见：[系统（System）](entries/System.md)、[共前台（Co-fronting）](entries/Co-Fronting.md)、[切换（Switch）](entries/Switch.md)、[成员（Alter）](entries/Alter.md)
-
+- [成员（Alter）](/entries/Alter.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [外投射（External Projection）](/entries/External-Projection.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)
+- [切换（Switch）](/entries/Switch.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-front]: Pluralpedia. (2024). [Fronting](https://pluralpedia.org/w/Fronting).

--- a/entries/Functional-Dissociation.md
+++ b/entries/Functional-Dissociation.md
@@ -1,6 +1,6 @@
 ---
 title: 功能性分离（Functional Dissociation）
-tags: [系统体验与机制]
+tags: [解离, 功能性分离, 核心概念, 常见例子, 自陈量表, 自我监测, 神经影像观察, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -50,10 +50,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [自动驾驶（Autopilot）](entries/Autopilot.md)
-- [切换（Switch）](entries/Switch.md)
-- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
-
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [病理性解离（Pathological Dissociation）](/entries/Pathological-Dissociation.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [迭代（Iteration）](/entries/Iteration.md)
 ## 参考资料
 
 [^cardena1994]: Cardeña, E. (1994). The domain of dissociation. In S. J. Lynn & J. W. Rhue (Eds.), *Dissociation: Clinical and theoretical perspectives* (pp. 15–31). New York: Guilford Press.

--- a/entries/Fusion.md
+++ b/entries/Fusion.md
@@ -1,6 +1,6 @@
 ---
 title: 融合（Fusion）
-tags: [系统体验与机制]
+tags: [整合, 主体体验, 积极效应, 持续时间, 实际考量, 可能风险, 功能整合, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - **与“整合”的关系**：在社群语境中，“整合”有时指广义的协作与记忆共享；“融合”则特指身份间的结构性合并。部分系统会使用“功能性整合”来描述达成高度合作但仍保持多重身份的状态。
 - **实际考量**：是否追求融合取决于系统对自我认同、创作或工作需求的考量。部分人选择维持多重身份，只要内部沟通与生活安全得到保障，同样被视为有效的恢复路径。
 
+## 相关条目
+
+- [迭代（Iteration）](/entries/Iteration.md)
+- [整合（Integration）](/entries/Integration.md)
+- [躯体认同（Body Ownership）](/entries/Body-Ownership.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
 ## 参考资料
 
 - International Society for the Study of Trauma and Dissociation. (2011). Guidelines for treating dissociative identity disorder in adults, third revision. *Journal of Trauma & Dissociation, 12*(2), 115–187.

--- a/entries/Gatekeeper.md
+++ b/entries/Gatekeeper.md
@@ -1,6 +1,6 @@
 ---
 title: 守门人（Gatekeeper）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 守门人, 前台与切换管理, 高层视角, 边界感知敏锐, 策略价值, 社群经验, 沟通与仲裁]
 updated: 2025-10-03
 ---
 
@@ -44,11 +44,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [管理者（Admin）](entries/Admin.md)
-- [内部自助者（ISH）](entries/Internal-Self-Helper-ISH.md)
-- [权限（Permissions）](entries/Permissions.md)
-- [保护者（Protector）](https://pluralpedia.org/w/Protector)
-
+- [核心（Core）](/entries/Core.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [成员（Alter）](/entries/Alter.md)
 ## 参考与延伸阅读
 
 Pluralpedia. (2024). *Gatekeeper*. [https://pluralpedia.org/w/Gatekeeper](https://pluralpedia.org/w/Gatekeeper)

--- a/entries/Grounding.md
+++ b/entries/Grounding.md
@@ -1,6 +1,6 @@
 ---
 title: 接地（Grounding）
-tags: [实践与支持]
+tags: [实践与支持, 接地, 主要目的, 诊断与临床, 核心特征, 应用建议, 常见误区, 常见练习]
 updated: 2025-10-03
 ---
 
@@ -82,6 +82,16 @@ updated: 2025-10-03
 
 ---
 
+## 相关条目
+
+- [冥想（Meditation）](/entries/Meditation.md)
+- [超级破碎（Polyfragmented）](/entries/Polyfragmented.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [创伤（Trauma）](/entries/Trauma.md)
 ## 参考资料
 
 [^接地-1]: [Grounding Techniques to Free Yourself From Stress, Cleveland Clinic](https://health.clevelandclinic.org/grounding-techniques/)

--- a/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md
+++ b/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md
@@ -1,6 +1,6 @@
 ---
 title: 虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）
-tags: [虚拟角色与文学影视作品]
+tags: [虚拟偶像与, 共创身份, 的边界 初音未来现象, 现实边界, 情感投射, 基础概念, 关键议题, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [系魂（Soulbond）](entries/Soulbond.md)
 - [外投射（External Projection）](entries/External-Projection.md)
 
+## 相关条目
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Head-Pressure.md
+++ b/entries/Head-Pressure.md
@@ -1,6 +1,6 @@
 ---
 title: 头压（Head Pressure）
-tags: [系统体验与机制]
+tags: [头压, 体验特征, 调节练习, 记录日志, 触发场景, 建立阈值, 头顶, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -59,10 +59,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [图帕（Tulpa）](entries/Tulpa.md)
-- [冥想（Meditation）](entries/Meditation.md)
-- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
-
+- [投影（Projection）](/entries/Projection.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
 ## 参考资料
 
 [^headpressure-pluralpedia]: Pluralpedia. (n.d.). [Head Pressure](https://pluralpedia.org/w/Head_pressure).

--- a/entries/Headspace-Inner-World.md
+++ b/entries/Headspace-Inner-World.md
@@ -1,6 +1,6 @@
 ---
 title: 内部空间（Headspace / Inner World）
-tags: [系统体验与机制]
+tags: [定义与同义词, 用于互动, 独立访问的心象环境, 幻境 指系统成员在内在感知中共享, 内部空间 亦称 里空间, 内部空间, 系统体验与机制, 里空间]
 updated: 2025-10-03
 ---
 
@@ -43,10 +43,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [系统（System）](entries/System.md)
-* [成员（Alter）](entries/Alter.md)
-* [接地（Grounding）](entries/Grounding.md)
-
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](/entries/Mixed-Systems-Xianyu.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-headspace]: Pluralpedia. (2024). [Headspace](https://pluralpedia.org/w/Headspace).

--- a/entries/Host.md
+++ b/entries/Host.md
@@ -1,6 +1,6 @@
 ---
 title: 宿主（Host）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 宿主, 角色可转移, 自我照顾与界限, 沟通协作, 宿主与前台的区别, 多宿主共存, 外部生活管理]
 updated: 2025-10-03
 ---
 
@@ -33,6 +33,16 @@ updated: 2025-10-03
 - **创造者角色**：在 tulpamancy 中，宿主通常是 tulpa 的最初创造者与主要互动对象。随着 tulpa 成熟，宿主需从“塑造者”转向“平等伙伴”的姿态，尊重 tulpa 的意见与界限。[^bell2023]
 - **共治协商**：HT 社群鼓励宿主与 tulpa 制定紧急应对、前台轮值与外部公开策略，减少误解与外界压力。
 
+## 相关条目
+
+- [图帕（Tulpa）](/entries/Tulpa.md)
+- [成员（Alter）](/entries/Alter.md)
+- [幻想伙伴（Imaginary Companion）](/entries/Imaginary-Companion.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [初始（Original）](/entries/Original.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
 ## 参考资料
 
 [^veissiere2016]: Veissière, S. P. L. (2016). Varieties of Tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.

--- a/entries/Iatrogenic-System.md
+++ b/entries/Iatrogenic-System.md
@@ -1,6 +1,6 @@
 ---
 title: 医源型系统（Iatrogenic System）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 医源型系统, 术语来源, 系统自检, 研究现状, 易感因素, 支持策略, 情境示例]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [内部自助者（ISH）](entries/Internal-Self-Helper-ISH.md)
-- [解离性身份障碍（DID）](entries/DID.md)
-- [融合（Fusion）](entries/Fusion.md)
-
+- [主体（Main）](/entries/Main.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [核心（Core）](/entries/Core.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [守门人（Gatekeeper）](/entries/Gatekeeper.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [成员（Alter）](/entries/Alter.md)
 ## 参考与延伸阅读
 
 [^iatrogenic-pluralpedia]: Pluralpedia. 2023. “Iatrogenic System.” [https://pluralpedia.org/w/Iatrogenic_system.](https://pluralpedia.org/w/Iatrogenic_system.)

--- a/entries/Imaginary-Companion.md
+++ b/entries/Imaginary-Companion.md
@@ -1,6 +1,6 @@
 ---
 title: 幻想伙伴（Imaginary Companion）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 幻想伙伴, 发展常见性, 文化差异, 寄生性念头或幻觉, 可塑性, 功能多样, 与多意识体概念的交叉]
 updated: 2025-10-03
 ---
 
@@ -40,3 +40,14 @@ updated: 2025-10-03
 [^harter2004]: Harter, S., & Taylor, M. (2004). The self and imaginary companions. In M. Taylor (Ed.), *Imaginary companions and the children who create them* (pp. 73–97). Oxford University Press.
 [^veissiere2016]: Veissière, S. P. L. (2016). Varieties of tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.
 [^americanpsychiatric2013]: American Psychiatric Association. (2013). *Diagnostic and statistical manual of mental disorders* (5th ed.). American Psychiatric Publishing.
+
+## 相关条目
+
+- [宿主（Host）](/entries/Host.md)
+- [图帕（Tulpa）](/entries/Tulpa.md)
+- [初始（Original）](/entries/Original.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [自发型（Spontaneous）](/entries/Spontaneous.md)
+- [主体（Main）](/entries/Main.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [保护者（Protector）](/entries/Protector.md)

--- a/entries/Independence.md
+++ b/entries/Independence.md
@@ -1,6 +1,6 @@
 ---
 title: 独立性（Independence）
-tags: [系统体验与机制]
+tags: [独立性, 维度划分, 风险应对, 连续谱, 评估工具, 神经生理指标, 系统体验与机制, 发展路径]
 updated: 2025-10-03
 ---
 
@@ -31,10 +31,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [主体（Main）](entries/Main.md)
-- [权限（Permissions）](entries/Permissions.md)
-- [融合（Fusion）](entries/Fusion.md)
-
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
 ## 参考与延伸阅读
 
 [^steinberg2014]: Steinberg, M. 2014. *Interview for Dissociative Disorders and PTSD: A Clinician’s Guide*. American Psychiatric Publishing.

--- a/entries/Integration.md
+++ b/entries/Integration.md
@@ -1,6 +1,6 @@
 ---
 title: 整合（Integration）
-tags: [系统体验与机制]
+tags: [整合, 阶段化治疗, 结构整合, 稳定性与安全感, 社会与文化考量, 目标多样性, 系统体验与机制, 技能训练]
 updated: 2025-10-03
 ---
 
@@ -39,10 +39,14 @@ Integration，融合，最终融合（Final Fusion）
 
 ## 相关条目
 
-- [解离](entries/Dissociation.md)
-- [融合](entries/Fusion.md)
-- [重构](entries/Reconstruction.md)
-
+- [融合（Fusion）](/entries/Fusion.md)
+- [迭代（Iteration）](/entries/Iteration.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [混合（Blending）](/entries/Blending.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
 ## 参考资料
 
 [^整合-1]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision*. [https://www.isst-d.org/wp-content/uploads/2019/02/ISSTD-Guidelines-Adult-DID-Treatment-2011.pdf](https://www.isst-d.org/wp-content/uploads/2019/02/ISSTD-Guidelines-Adult-DID-Treatment-2011.pdf)

--- a/entries/Internal-Self-Helper-ISH.md
+++ b/entries/Internal-Self-Helper-ISH.md
@@ -1,6 +1,6 @@
 ---
 title: 内部自助者（Internal Self Helper，ISH）
-tags: [系统角色与类型]
+tags: [解离性身份障碍 DID, 系统角色与类型, 内部自助者, 来源背景, 风险应对, 身份形态, 记录建议, 沟通技巧]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [守门人（Gatekeeper）](entries/Gatekeeper.md)
-- [系统体验：权限（Permissions）](entries/Permissions.md)
-- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
-
+- [管理者（Admin）](/entries/Admin.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [主体（Main）](/entries/Main.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
+- [混合（Blending）](/entries/Blending.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
 ## 参考与延伸阅读
 
 [^ish-pluralpedia]: Pluralpedia. 2023. “Internal Self Helper.” [https://pluralpedia.org/w/Internal_Self_Helper.](https://pluralpedia.org/w/Internal_Self_Helper.)

--- a/entries/Intrusive-Thoughts.md
+++ b/entries/Intrusive-Thoughts.md
@@ -1,6 +1,6 @@
 ---
 title: 侵入性思维（Intrusive Thoughts）
-tags: [系统体验与机制]
+tags: [侵入性思维, 药物与治疗, 核心特征, 应对策略, 常见误区, 常见主题, 参阅, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -87,6 +87,16 @@ updated: 2025-10-03
 * [应激反应](entries/Stress-Response.md)
 * [接地](entries/Grounding.md)
 
+## 相关条目
+
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [冥想（Meditation）](/entries/Meditation.md)
+- [切换（Switch）](/entries/Switch.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [接地（Grounding）](/entries/Grounding.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
 ## 参考
 
 * American Psychiatric Association. (2013). *Diagnostic and Statistical Manual of Mental Disorders (5th ed.)*. Arlington, VA: American Psychiatric Publishing.

--- a/entries/Iteration.md
+++ b/entries/Iteration.md
@@ -1,6 +1,6 @@
 ---
 title: 迭代（Iteration）
-tags: [系统体验与机制]
+tags: [整合, 迭代, 高压或创伤复燃, 长期整合目标的弹性, 重构, 重建内部沟通, 融合后的反弹, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -28,6 +28,16 @@ updated: 2025-10-03
 - **融合**：强调多个身份结构性合并，若维持稳定可减少未来迭代风险。
 - **重构**：指单一成员退场后出现新成员承担原角色，通常规模小于迭代（参见“[重构](entries/Reconstruction.md)”）。
 
+## 相关条目
+
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [整合（Integration）](/entries/Integration.md)
+- [躯体认同（Body Ownership）](/entries/Body-Ownership.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
 ## 参考资料
 
 - Fine, C. G. (1999). The tactical-integration model for the treatment of dissociative identity disorder. *American Journal of Psychotherapy, 53*(3), 361–376.

--- a/entries/Kafka-Metamorphosis-Identity-Dissolution.md
+++ b/entries/Kafka-Metamorphosis-Identity-Dissolution.md
@@ -1,6 +1,6 @@
 ---
 title: 卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）
-tags: [虚拟角色与文学影视作品]
+tags: [解离, 卡夫卡 变形记 与异化的身份解体, 身体异化, 语言断层, 家庭动力, 解体意象, 基础概念, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [非我感（Depersonalization）](entries/Depersonalization.md)
 - [独立性（Independence）](entries/Independence.md)
 
+## 相关条目
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Little.md
+++ b/entries/Little.md
@@ -1,6 +1,6 @@
 ---
 title: 小孩意识体（Little / Child Part）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 小孩意识体, 发展阶段特征, 时间感差异, 支持性空间, 情感需求强烈, 回归状态, 前台安排]
 updated: 2025-10-03
 ---
 
@@ -42,3 +42,14 @@ updated: 2025-10-03
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
 [^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
+
+## 相关条目
+
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Lovecraft-Tulpa-Motifs.md
+++ b/entries/Lovecraft-Tulpa-Motifs.md
@@ -1,6 +1,6 @@
 ---
 title: 洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）
-tags: [虚拟角色与文学影视作品]
+tags: [知识与具现, 影射, 自我与他者边界, 洛夫克拉夫特作品中的 心灵造物 与, 文化挪用讨论, 基础概念, 主题解读, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ H. P. 洛夫克拉夫特的克苏鲁神话作品中，常出现由人类心智�
 - [心灵造物（Servitor）](entries/Servitor.md)
 - [外投射（External Projection）](entries/External-Projection.md)
 
+## 相关条目
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Madoka-Magica-Kyubey-Otherness.md
+++ b/entries/Madoka-Magica-Kyubey-Otherness.md
@@ -1,6 +1,6 @@
 ---
 title: 《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）
-tags: [虚拟角色与文学影视作品]
+tags: [魔法少女小圆 中的丘比与契约式 他者, 情感空白, 契约机制, 信息控制, 角色特征, 基础概念, 社群解读, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [心灵造物（Servitor）](entries/Servitor.md)
 - [权限（Permissions）](entries/Permissions.md)
 
+## 相关条目
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Main.md
+++ b/entries/Main.md
@@ -1,6 +1,6 @@
 ---
 title: 主体（Main）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 主体, 语境差异, 风险应对, 角色流动性, 职责划分, 社会角色期望, 执行功能整合]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [宿主（Host）](entries/Host.md)
-- [管理者（Admin）](entries/Admin.md)
-- [伪主体（Fauxmain）](entries/Fauxmain.md)
-
+- [人格面具（Persona）](/entries/Persona.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [医源型系统（Iatrogenic System）](/entries/Iatrogenic-System.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [管理者（Admin）](/entries/Admin.md)
 ## 参考与延伸阅读
 
 [^dsm5]: American Psychiatric Association. 2013. *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). American Psychiatric Publishing.

--- a/entries/Mania.md
+++ b/entries/Mania.md
@@ -1,6 +1,6 @@
 ---
 title: 躁狂（Mania）
-tags: [诊断与临床]
+tags: [躁狂, 行为, 精神病性症状, 生理与神经系统, 情绪与认知, ICD11要点, DSM5TR要点, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -63,6 +63,16 @@ _若出现自我伤害、他人伤害或判断力显著受损，请立即联系�
 3. **安全与环境管理**：建立危机计划，减少高风险财务或性行为，必要时限制外出驾驶；在多意识系统中明确由谁负责监测睡眠与药物、如何共享状况变化。
 4. **生活方式**：规律作息、避免兴奋剂与酒精、维持营养及补水；在创意或工作高峰时预设复盘机制，防止过度承诺。
 
+## 相关条目
+
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [焦虑（Anxiety）](/entries/Anxiety.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [孤独症谱系（Autism Spectrum Disorder）](/entries/Autism-Spectrum-Disorder.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
 ## 参考资料
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). American Psychiatric Publishing.

--- a/entries/Meditation.md
+++ b/entries/Meditation.md
@@ -1,6 +1,6 @@
 ---
 title: 冥想（Meditation）
-tags: [实践与支持]
+tags: [实践与支持, 冥想练习, 主要取向, 风险与注意事项, 诊断与临床, 核心特征, 常见误区, 实务建议]
 updated: 2025-10-03
 ---
 
@@ -77,6 +77,16 @@ updated: 2025-10-03
 
 ---
 
+## 相关条目
+
+- [接地（Grounding）](/entries/Grounding.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [超级破碎（Polyfragmented）](/entries/Polyfragmented.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [切换（Switch）](/entries/Switch.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
 ## 参考资料
 
 [^冥想-1]: Kabat-Zinn, J. (2013). *Full Catastrophe Living* (Revised ed.). Bantam Books.

--- a/entries/Memory-Holder.md
+++ b/entries/Memory-Holder.md
@@ -1,6 +1,6 @@
 ---
 title: 记忆持有者（Memory Holder）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 记忆持有者, 记忆范围集中, 情绪负荷较高, 迫害者, 记录者 观察者, 技能或知识保管, 创伤记忆守护]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 [^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
 [^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+
+## 相关条目
+
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Memory-Shielding.md
+++ b/entries/Memory-Shielding.md
@@ -1,6 +1,6 @@
 ---
 title: 记忆屏蔽（Memory Shielding）
-tags: [系统体验与机制]
+tags: [记忆屏蔽, 目的多样, 形式分类, 神经生物学基础, 治疗合作, 意象法实施, 系统体验与机制, 心理防御]
 updated: 2025-10-03
 ---
 
@@ -31,10 +31,14 @@ Memory Shielding、Amnesiacflux、屏蔽记忆
 
 ## 相关条目
 
-- [独有记忆（Exomemory）](entries/Exomemory.md)
-- [权限（Permissions）](entries/Permissions.md)
-- [封存（Sequestration）](entries/Sequestration.md)
-
+- [独立性（Independence）](/entries/Independence.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
 ## 参考与延伸阅读
 
 [^dsm5]: American Psychiatric Association. 2013. *Diagnostic and Statistical Manual of Mental Disorders* (5th ed.). American Psychiatric Publishing.

--- a/entries/Mixed-Systems-Xianyu.md
+++ b/entries/Mixed-Systems-Xianyu.md
@@ -1,6 +1,6 @@
 ---
 title: 混合型系统（Mixed Systems, Xianyu Theory）
-tags: [系统体验与机制]
+tags: [生态位定位, 特征, 定义与同义词, 复合生态位系统, 叠加型系统, 混合型系统, 系统体验与机制, 灵活性]
 updated: 2025-10-03
 ---
 
@@ -90,14 +90,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [弦羽理论生态位分类法](entries/Xianyu-Theory-Niche-Classification.md)
-- [单一类系统（Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
-- [家族式系统（Xianyu Theory）](entries/Family-Systems-Xianyu.md)
-- [系魂型系统（Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/Trauma.md)
-
----
-
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)
 ## 参考与来源
 
 - 原文：弦羽系统提出的《弦羽理论生态位分类法》手稿

--- a/entries/Mr-Robot-DID-Narrative.md
+++ b/entries/Mr-Robot-DID-Narrative.md
@@ -1,6 +1,6 @@
 ---
 title: 《隐形人》（Mr. Robot）中的人格分裂叙事
-tags: [虚拟角色与文学影视作品]
+tags: [隐形人, 创伤揭示, 叙事不可靠, 协商与边界, 基础概念, 关键主题, 社群反响, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
 - [创伤（Trauma）](entries/Trauma.md)
 
+## 相关条目
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Narcissistic-Personality-Disorder-NPD.md
+++ b/entries/Narcissistic-Personality-Disorder-NPD.md
@@ -1,6 +1,6 @@
 ---
 title: 自恋型人格障碍（Narcissistic Personality Disorder，NPD）
-tags: [诊断与临床]
+tags: [自恋型人格障碍, NPD, 界限与合作, 心理治疗, 共病处理, 诊断与临床, 治疗与支持, 临床关注点]
 updated: 2025-10-03
 ---
 
@@ -51,6 +51,16 @@ ICD-11 将人格障碍划分为单一诊断并通过严重程度与特质修饰�
 - **界限与合作**：治疗关系中需建立清晰界限，鼓励现实反馈与自我反思。
 - **共病处理**：若存在情绪障碍、冲动控制或物质问题，应同步给予相应的药物与心理干预。
 
+## 相关条目
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [创伤（Trauma）](/entries/Trauma.md)
 ## 参考资料
 
 1. American Psychiatric Association. _Diagnostic and Statistical Manual of Mental Disorders_ (5th ed., Text Revision), 2022.

--- a/entries/Neurodiversity.md
+++ b/entries/Neurodiversity.md
@@ -1,6 +1,6 @@
 ---
 title: 神经多样性（Neurodiversity）
-tags: [相关概念与理论, 社群与文化]
+tags: [神经多样性, 跨标签协作, 自我决定权, 结构性资源差距, 社会模型, 知识传播, 社群与文化, 相关概念与理论]
 updated: 2025-10-03
 ---
 
@@ -44,11 +44,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [孤独症谱系（ASD）](entries/Autism-Spectrum-Disorder.md)
-- [注意缺陷多动障碍（ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
-- [创伤（Trauma）](entries/Trauma.md)
-- [多意识体（Plurality）](entries/Plurality.md)
-
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [感官调节策略（Sensory Regulation Strategies）](/entries/Sensory-Regulation-Strategies.md)
 ## 参考与延伸阅读
 
 1. Singer, J. (1998). *NeuroDiversity: The Birth of an Idea*. (未出版荣誉论文). University of Technology Sydney.

--- a/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md
+++ b/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md
@@ -1,6 +1,6 @@
 ---
 title: 《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）
-tags: [虚拟角色与文学影视作品]
+tags: [莉莉丝, 存在的你, 边界主题, 和我 与, 共存视角, 互动机制, 不, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -26,6 +26,16 @@ updated: 2025-10-03
 - [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
 - [心像空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
 
+## 相关条目
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/OCD.md
+++ b/entries/OCD.md
@@ -1,6 +1,6 @@
 ---
 title: 强迫症（Obsessive-Compulsive Disorder, OCD）
-tags: [诊断与临床]
+tags: [定义与同义词, 强迫性障碍, 强迫症, 评估与治疗, 系统适用的自助建议, 社群与临床语境, 诊断与临床, 常见误区]
 updated: 2025-10-03
 ---
 
@@ -113,12 +113,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [侵入性思维](entries/Intrusive-Thoughts.md)
-* [解离](entries/Dissociation.md)
-* [抑郁障碍](entries/Depressive-Disorders.md)
-
----
-
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [切换（Switch）](/entries/Switch.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [创伤（Trauma）](/entries/Trauma.md)
+- [闪回（Flashback）](/entries/Flashback.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](/entries/Narcissistic-Personality-Disorder-NPD.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
 ## 参考与延伸阅读
 
 1. APA. (2022). *DSM-5-TR: Diagnostic and Statistical Manual of Mental Disorders*.

--- a/entries/OSDD.md
+++ b/entries/OSDD.md
@@ -1,6 +1,6 @@
 ---
 title: 其他特定解离性障碍（OSDD）
-tags: [诊断与临床]
+tags: [解离性身份障碍 DID, 其他特定解离性障碍 OSDD, 其他特定解离性障碍, 定义与同义词, 非正式, 非典型解离障碍, 部分, 解离性身份障碍]
 updated: 2025-10-03
 ---
 
@@ -71,12 +71,14 @@ DSM-5 与 DSM-5-TR 在文字说明中给出了几个典型的“例子”，帮�
 
 ## 相关条目
 
-- [解离性身份障碍（DID）](entries/DID.md)
-- [部分解离性身份障碍（PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
-- [人格解体/现实解体障碍（DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-- [创伤](entries/Trauma.md)
-
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [系统（System）](/entries/System.md)
+- [混合（Blending）](/entries/Blending.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](/entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
 ## 参考
 
 [^Brand2021]: Brand, B. L., & Loewenstein, R. J. (2021). Dissociative disorders: An overview of assessment, phenomenology, and treatment. _Journal of Psychiatric Practice_, 27(3), 170–182.

--- a/entries/Original.md
+++ b/entries/Original.md
@@ -1,6 +1,6 @@
 ---
 title: 初始（Original）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 初始, 身份认同议题, 角色可塑性, 多初始系统, 外部生活记忆的主轴, 与宿主的并列, 社区用法与变体]
 updated: 2025-10-03
 ---
 
@@ -35,3 +35,14 @@ updated: 2025-10-03
 [^putnam1989]: Putnam, F. W. (1989). *Diagnosis and treatment of multiple personality disorder*. Guilford Press.
 [^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
 [^veissiere2016]: Veissière, S. P. L. (2016). Varieties of tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.
+
+## 相关条目
+
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [宿主（Host）](/entries/Host.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [照顾者（Caregiver）](/entries/Caregiver.md)

--- a/entries/PTSD.md
+++ b/entries/PTSD.md
@@ -1,6 +1,6 @@
 ---
 title: 创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）
-tags: [诊断与临床]
+tags: [创伤后应激障碍 PTSD, 定义与同义词, 创伤后应激反应障碍, 社群与临床语境, 常见误区, 实务建议, 诊断与临床, 参考与延伸阅读]
 updated: 2025-10-03
 ---
 
@@ -81,16 +81,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [创伤](entries/Trauma.md)
-* [复杂性创伤后应激障碍](entries/CPTSD.md)
-* [解离性身份障碍](entries/DID.md)
-* [解离性遗忘](entries/Dissociative-Amnesia-DA.md)
-* [人格解体/现实解体障碍](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-* [应激反应](entries/Stress-Response.md)
-* [躯体化障碍](entries/Somatic-Symptom-Disorder-SSD.md)
-
----
-
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
+- [闪回（Flashback）](/entries/Flashback.md)
+- [创伤（Trauma）](/entries/Trauma.md)
+- [切换（Switch）](/entries/Switch.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [冥想（Meditation）](/entries/Meditation.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
 ## 参考与延伸阅读
 
 1. APA. (2022). *DSM-5-TR: Diagnostic and Statistical Manual of Mental Disorders*.

--- a/entries/Paranoia-Agent-Collective-Consciousness.md
+++ b/entries/Paranoia-Agent-Collective-Consciousness.md
@@ -1,6 +1,6 @@
 ---
 title: 《妄想代理人》（Paranoia Agent）与集体意识的具象化
-tags: [虚拟角色与文学影视作品]
+tags: [妄想代理人, 现实与虚构的模糊, 共享幻象, 解离相关象征, 基础概念, 观众解读, 媒体呈现, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
 - [图帕（Tulpa）](entries/Tulpa.md)
 
+## 相关条目
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Partial-Dissociative-Identity-Disorder-PDID.md
+++ b/entries/Partial-Dissociative-Identity-Disorder-PDID.md
@@ -1,6 +1,6 @@
 ---
 title: 部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）
-tags: [诊断与临床]
+tags: [解离性身份障碍 DID, 部分解离性身份障碍, 风险应对, 身体或动作的失控感, 身份相关的象征性体验, 起病时间, 记忆缺失的程度, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -130,14 +130,14 @@ DSM-5 未单列部分解离性身份障碍，临床上通常归入 **OSDD-1（Ot
 
 ## 相关条目
 
-- [解离性身份障碍（DID）](entries/DID.md)
-- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
-- [人格解体/现实解体障碍（DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-- [创伤后应激障碍（PTSD）](entries/PTSD.md)
-- [闪回（Flashback）](entries/Flashback.md)
-
----
-
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [其他特定解离性障碍（OSDD）](/entries/OSDD.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](/entries/Fight-Club-1999-Identity-Metaphor.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
 ## 延伸阅读与资源
 
 - 国际解离性障碍协会（ISSTD）发布的《成人解离障碍治疗指南》。

--- a/entries/Pathological-Dissociation.md
+++ b/entries/Pathological-Dissociation.md
@@ -1,6 +1,6 @@
 ---
 title: 病理性解离（Pathological Dissociation）
-tags: [诊断与临床]
+tags: [解离, 病理性解离, 临床框架, 辅量资料, 触发因素, 自评工具, 结构性解离理论, 诊断与临床]
 updated: 2025-10-03
 ---
 
@@ -52,12 +52,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
-- [解离性身份障碍（DID）](entries/DID.md)
-- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
-- [人格解体/现实解体障碍（DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-- [创伤后应激障碍（PTSD）](entries/PTSD.md)
-
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](/entries/DID.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [功能性分离（Functional Dissociation）](/entries/Functional-Dissociation.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](/entries/Alcohol-Induced-Dissociation.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [成员（Alter）](/entries/Alter.md)
+- [复杂性创伤后应激障碍（CPTSD）](/entries/CPTSD.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](/entries/Partial-Dissociative-Identity-Disorder-PDID.md)
 ## 参考资料
 
 [^apa2022]: American Psychiatric Association. (2022). *Diagnostic and Statistical Manual of Mental Disorders* (5th ed., text rev.). Washington, DC: Author.

--- a/entries/Performer-Executive.md
+++ b/entries/Performer-Executive.md
@@ -1,6 +1,6 @@
 ---
 title: 执行者（Performer / Executive）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 执行者, 高功能导向, 轮班机制, 责任感强, 情绪分隔, 多执行者协作, 常见特征]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 [^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
+
+## 相关条目
+
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Permissions.md
+++ b/entries/Permissions.md
@@ -1,6 +1,6 @@
 ---
 title: 权限（Permissions）
-tags: [系统体验与机制]
+tags: [权限, 安全层级, 多维度构成, 动态协商, 紧急协议, 神经网络视角, 权限矩阵, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [主体（Main）](entries/Main.md)
-- [管理者（Admin）](entries/Admin.md)
-- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
-
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [成员（Alter）](/entries/Alter.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
 ## 参考与延伸阅读
 
 [^reinders2019]: Reinders, A. A. T. S., et al. 2019. “Differential Autonomic Nervous System Activity in Dissociative Identity Disorder.” *Journal of Abnormal Psychology* 128(6): 531–543.

--- a/entries/Persecutor.md
+++ b/entries/Persecutor.md
@@ -1,6 +1,6 @@
 ---
 title: 迫害者（Persecutor）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 迫害者, 高度警觉, 验证其意图, 难以信任支持, 阶段化治疗, 转化为保护者, 自责与羞耻]
 updated: 2025-10-03
 ---
 
@@ -43,3 +43,14 @@ updated: 2025-10-03
 [^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
 [^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+
+## 相关条目
+
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Persona.md
+++ b/entries/Persona.md
@@ -1,6 +1,6 @@
 ---
 title: 人格面具（Persona）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 人格面具, 起源, 风险应对, 解离研究关联, 自我评估, 心理动力机制, 在多意识体语境中的使用]
 updated: 2025-10-03
 ---
 
@@ -31,10 +31,14 @@ _仅供参考，**不能**替代专业医师的诊断和治疗方案。如果有
 
 ## 相关条目
 
-- [主体（Main）](entries/Main.md)
-- [宿主（Host）](entries/Host.md)
-- [管理者（Admin）](entries/Admin.md)
-
+- [主体（Main）](/entries/Main.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [系魂（Soulbond）](/entries/Soulbond.md)
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [独立性（Independence）](/entries/Independence.md)
 ## 参考与延伸阅读
 
 [^jung1959]: Jung, C. G. 1959. *The Archetypes and the Collective Unconscious*. Princeton University Press.

--- a/entries/Plurality-Basics.md
+++ b/entries/Plurality-Basics.md
@@ -1,6 +1,6 @@
 ---
 title: 多重意识体基础（Plurality Basics）
-tags: [系统体验与机制]
+tags: [解离性身份障碍 DID, 多重意识体基础, 非病理化视角, 身份认可, 资源消耗, 解离谱系观点, 系统体验与机制, 解离性身份障碍]
 updated: 2025-10-03
 ---
 
@@ -53,6 +53,16 @@ updated: 2025-10-03
 - **使用地面化技术**：在切换或感官过载时，运用呼吸、触感或五感扫描等技巧保持稳定。
 - **获取社群资源**：加入互助社群、阅读术语库、参加教育资源可以减少孤立感并获取经验分享。
 
+## 相关条目
+
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [系统（System）](/entries/System.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
 ## 参考资料
 
 [^plurality-def]: Lopez, C., & Tait, C. (2020). Plural identities and collaborative functioning in dissociative systems. *Journal of Plural Studies, 5*(2), 15-32.

--- a/entries/Plurality.md
+++ b/entries/Plurality.md
@@ -1,6 +1,6 @@
 ---
 title: 多意识体（Plurality）
-tags: [系统体验与机制]
+tags: [解离性身份障碍 DID, 多意识体, 非病理化视角, 身份认可, 资源消耗, 解离谱系观点, 系统体验与机制, 解离性身份障碍]
 updated: 2025-10-03
 ---
 
@@ -51,6 +51,16 @@ updated: 2025-10-03
 - **使用地面化技术**：在切换或感官过载时，运用呼吸、触感或五感扫描等技巧保持稳定。
 - **获取社群资源**：加入互助社群、阅读术语库、参加教育资源可以减少孤立感并获取经验分享。
 
+## 相关条目
+
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [系统（System）](/entries/System.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [独立性（Independence）](/entries/Independence.md)
 ## 参考资料
 
 [^plurality-def]: Lopez, C., & Tait, C. (2020). Plural identities and collaborative functioning in dissociative systems. *Journal of Plural Studies, 5*(2), 15-32.

--- a/entries/Polyfragmented.md
+++ b/entries/Polyfragmented.md
@@ -1,6 +1,6 @@
 ---
 title: 超级破碎（Polyfragmented）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 超级破碎, 诊断与临床, 识别与评估, 核心特征, 支援策略, 常见误区, 参考与延伸阅读]
 updated: 2025-10-03
 ---
 
@@ -69,12 +69,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [碎片（Fragment）](entries/Fragment.md)
-* [管理者（Admin）](entries/Admin.md)
-* [解离性身份障碍（DID）](entries/DID.md)
-
----
-
+- [冥想（Meditation）](/entries/Meditation.md)
+- [接地（Grounding）](/entries/Grounding.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [成员（Alter）](/entries/Alter.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
 ## 参考与延伸阅读
 
 [^polyfragmented-pluralpedia]: Pluralpedia. (n.d.). [Polyfragmented](https://pluralpedia.org/w/Polyfragmented).

--- a/entries/Projection.md
+++ b/entries/Projection.md
@@ -1,6 +1,6 @@
 ---
 title: 投影（Projection）
-tags: [系统体验与机制]
+tags: [投影, 视觉化呈现, 感官化反馈, 空间定位, 多意识体系统, 体验特点, 社群语境, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -32,11 +32,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [外投射（External Projection）](entries/External-Projection.md)
-- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
-- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
-- [接地（Grounding）](entries/Grounding.md)
-
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
 ## 参考资料
 
 [Projection](https://pluralpedia.org/w/Projection).

--- a/entries/Protector.md
+++ b/entries/Protector.md
@@ -1,6 +1,6 @@
 ---
 title: 保护者（Protector）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 防御者, 角色分化, 安全导向, 策略灵活, 危机协调, 前台守卫, 与迫害者转换]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
 [^boon2011]: Boon, S., Steele, K., & Van der Hart, O. (2011). *Coping with trauma-related dissociation: Skills training for patients and therapists*. W. W. Norton & Company.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+
+## 相关条目
+
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Reconstruction.md
+++ b/entries/Reconstruction.md
@@ -1,6 +1,6 @@
 ---
 title: 重构（Reconstruction）
-tags: [系统体验与机制]
+tags: [重构, 迭代, 角色替换, 融合与整合, 生命周期事件, 治疗协作, 外部沟通, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - **迭代**：重构聚焦于单一或少数成员的更替；若系统大规模失衡并重新组建，则更接近“[迭代](entries/Iteration.md)”的描述。
 - **融合与整合**：重构不等同于融合。融合强调身份间合并；重构则是在保持多重身份前提下的角色转换。若新成员能共享信息与合作，同样可视为整合进展的一部分。
 
+## 相关条目
+
+- [迭代（Iteration）](/entries/Iteration.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [躯体认同（Body Ownership）](/entries/Body-Ownership.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [独立性（Independence）](/entries/Independence.md)
 ## 参考资料
 
 - Putnam, F. W. (1989). *Diagnosis and treatment of multiple personality disorder*. Guilford Press.

--- a/entries/Regression-In-Psychology.md
+++ b/entries/Regression-In-Psychology.md
@@ -1,6 +1,6 @@
 ---
 title: 退行（Regression in Psychology）
-tags: [系统体验与机制]
+tags: [退行, 稳定化与接地技巧, 界限与日常结构, 慢性或急性压力, 发展性补偿, 创伤提醒, 关系动力, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -40,6 +40,16 @@ updated: 2025-10-03
 - **发展性补偿**：透过心理治疗、游戏疗法或团体支持补足早期未被满足的发展任务，使退行逐渐减少。
 - **界限与日常结构**：在照料环境中维持温柔且清晰的界限，帮助个体在安全中重新练习成熟技能。
 
+## 相关条目
+
+- [迭代（Iteration）](/entries/Iteration.md)
+- [重构（Reconstruction）](/entries/Reconstruction.md)
+- [躯体认同（Body Ownership）](/entries/Body-Ownership.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [权限（Permissions）](/entries/Permissions.md)
+- [融合（Fusion）](/entries/Fusion.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
 ## 参考文献
 
 [^退行-1]: American Psychological Association. (2023). *Regression*. APA Dictionary of Psychology. [https://dictionary.apa.org/regression](https://dictionary.apa.org/regression)

--- a/entries/Schizophrenia-SC.md
+++ b/entries/Schizophrenia-SC.md
@@ -1,6 +1,6 @@
 ---
 title: 精神分裂症（Schizophrenia，SC）
-tags: [诊断与临床]
+tags: [精神分裂症, 药物治疗, 心理社会干预, 康复与支持, 病程与共病, 治疗与支持, 诊断与临床, 诊断要点]
 updated: 2025-10-03
 ---
 
@@ -55,6 +55,16 @@ ICD-11 对精神分裂症的诊断强调以下要点：
 - **心理社会干预**：个案管理、家庭干预、社交技能训练、认知行为治疗等有助于改善复发率与功能。
 - **康复与支持**：提供职业康复、社区支持、早期干预与复发预警教育，帮助个体维持生活品质。
 
+## 相关条目
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](/entries/Somatic-Symptom-Disorder-SSD.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](/entries/Narcissistic-Personality-Disorder-NPD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
 ## 参考资料
 
 1. American Psychiatric Association. _Diagnostic and Statistical Manual of Mental Disorders_ (5th ed., Text Revision), 2022.

--- a/entries/Sense-Of-Presence.md
+++ b/entries/Sense-Of-Presence.md
@@ -1,6 +1,6 @@
 ---
 title: 存在感（Sense of Presence）
-tags: [系统体验与机制]
+tags: [存在感, 生理状态, 感官线索, 意识共存, 情绪同频, 建立信号, 系统体验与机制, 幻觉]
 updated: 2025-10-03
 ---
 
@@ -38,6 +38,16 @@ updated: 2025-10-03
 - **建立信号**：当班成员可请其他人以特定感官提示（如轻敲或特定词语）表示“在场”，减少误判。
 - **与专业者沟通**：若存在感变化伴随解离加剧或影响功能，可与熟悉多重意识体验的治疗者讨论。
 
+## 相关条目
+
+- [意识共存（Co-consciousness）](/entries/Co-Consciousness.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [独立性（Independence）](/entries/Independence.md)
 ## 参考资料
 
 [^存在感-1]: Veissière, S. P. L., et al. (2020). Tulpamancy: Virtual companions, identity, and religion. *Phenomenology and the Cognitive Sciences, 19*(3), 619-644.

--- a/entries/Sensory-Regulation-Strategies.md
+++ b/entries/Sensory-Regulation-Strategies.md
@@ -1,6 +1,6 @@
 ---
 title: 感官调节策略（Sensory Regulation Strategies）
-tags: [实践与支持, 感官调节]
+tags: [实践与支持, 感官调节策略, 感官特征记录, 身体信号, 资源评估, 环境扫描, 渐进尝试, 感官调节]
 updated: 2025-10-03
 ---
 
@@ -65,11 +65,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [接地（Grounding）](entries/Grounding.md)
-- [应激反应（Stress Response）](entries/Stress-Response.md)
-- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
-- [多意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
-
+- [神经多样性（Neurodiversity）](/entries/Neurodiversity.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
 ## 参考与延伸阅读
 
 1. Dunn, W. (2014). *Sensory Profile 2 Manual*. Pearson.

--- a/entries/Sequestration.md
+++ b/entries/Sequestration.md
@@ -1,6 +1,6 @@
 ---
 title: 封存（Sequestration）
-tags: [系统体验与机制]
+tags: [封存, 高危冲动或自伤意图, 非永久解决方案, 评估风险, 强烈情绪风暴, 尊重差异, 系统体验与机制, 创伤记忆泛滥]
 updated: 2025-10-03
 ---
 
@@ -33,6 +33,16 @@ updated: 2025-10-03
 - **评估风险**：若成员持续要求被封或封存后失联，需与专业者讨论是否存在严重创伤或自我伤害风险。
 - **尊重差异**：不同系统对封存的理解各异，有些会以象征性“安置”“休眠”取代，重点在确保安全与尊重。
 
+## 相关条目
+
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [应激反应（Stress Response）](/entries/Stress-Response.md)
+- [独立性（Independence）](/entries/Independence.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [非我感（Depersonalization）](/entries/Depersonalization.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
 ## 参考资料
 
 [^封存-1]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for Treating Dissociative Identity Disorder in Adults, Third Revision*.

--- a/entries/Servitor.md
+++ b/entries/Servitor.md
@@ -1,6 +1,6 @@
 ---
 title: 傀儡（Servitor）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 傀儡, 功能优先, 与图帕的区分, 适用场景, 边界管理, 任务老化, 基础概念]
 updated: 2025-10-03
 ---
 
@@ -30,10 +30,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [图帕（Tulpa）](entries/Tulpa.md)
-- [管理者（Admin）](entries/Admin.md)
-- [伪主体（Fauxmain）](entries/Fauxmain.md)
-
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](/entries/Touhou-Tulpa-Fandom.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
 ## 参考与延伸阅读
 
 [^servitor-guide]: Kovi. 2017. “Servitor Creation Guide.” *tulpa.io*. [https://tulpa.io/servitor-creation-guide.](https://tulpa.io/servitor-creation-guide.)

--- a/entries/Single-Class-Systems-Xianyu.md
+++ b/entries/Single-Class-Systems-Xianyu.md
@@ -1,6 +1,6 @@
 ---
 title: 单一类系统（Single-Class Systems, Xianyu Theory）
-tags: [系统体验与机制]
+tags: [生态位定位, 特征, 定义与同义词, 单核型系统, 单一生态位系统, 单一类系统, 系统体验与机制, 演化视角]
 updated: 2025-10-03
 ---
 
@@ -80,4 +80,11 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [弦羽理论生态位分类法](entries/Xianyu-Theory-Niche-Classification.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](/entries/Mixed-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)

--- a/entries/Somatic-Symptom-Disorder-SSD.md
+++ b/entries/Somatic-Symptom-Disorder-SSD.md
@@ -1,6 +1,6 @@
 ---
 title: 躯体化障碍（Somatic Symptom Disorder，SSD）
-tags: [诊断与临床]
+tags: [躯体化障碍, SSD, 药物治疗, 综合照护, 心理治疗, 心理教育与医患联盟, 诊断与临床, 评估与鉴别]
 updated: 2025-10-03
 ---
 
@@ -50,6 +50,16 @@ DSM-5-TR 允许按照症状持续时间（急性 < 6 个月；慢性 ≥ 6 个�
 - **药物治疗**：若合并抑郁或焦虑症状，可考虑抗抑郁药物；应避免过度使用止痛药或镇静药。
 - **综合照护**：鼓励规律生活、运动与社会支持，必要时与躯体科、康复、精神卫生团队协作。
 
+## 相关条目
+
+- [精神分裂症（Schizophrenia，SC）](/entries/Schizophrenia-SC.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](/entries/Narcissistic-Personality-Disorder-NPD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](/entries/Borderline-Personality-Disorder-BPD.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](/entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [抑郁障碍（Depressive Disorders）](/entries/Depressive-Disorders.md)
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](/entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [躁狂（Mania）](/entries/Mania.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
 ## 参考资料
 
 1. American Psychiatric Association. _Diagnostic and Statistical Manual of Mental Disorders_ (5th ed., Text Revision), 2022.

--- a/entries/Soul-Linked-Systems-Xianyu.md
+++ b/entries/Soul-Linked-Systems-Xianyu.md
@@ -1,6 +1,6 @@
 ---
 title: 系魂型系统（Soul-Linked Systems, Xianyu Theory）
-tags: [系统体验与机制]
+tags: [定义与同义词, 通灵型系统, 灵魂联结系统, 灵性中介系统, 系魂型系统, 社群功能, 系统体验与机制, 独特性]
 updated: 2025-10-03
 ---
 
@@ -74,14 +74,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [弦羽理论生态位分类法](entries/Xianyu-Theory-Niche-Classification.md)
-- [单一类系统（Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
-- [混合型系统（Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
-- [家族式系统（Xianyu Theory）](entries/Family-Systems-Xianyu.md)
-- [创伤（Trauma）](entries/Trauma.md)
-
----
-
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](/entries/Mixed-Systems-Xianyu.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)
 ## 参考与来源
 
 - 原文：弦羽系统提出的《弦羽理论生态位分类法》手稿

--- a/entries/Soulbond.md
+++ b/entries/Soulbond.md
@@ -1,6 +1,6 @@
 ---
 title: 系魂（Soulbond）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 系魂, 起源背景, 体验特征, 风险应对, 身份持续性, 记录管理, 沟通与边界]
 updated: 2025-10-03
 ---
 
@@ -27,10 +27,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [特殊认同（Alterhuman）](entries/Alterhuman.md)
-- [人格面具（Persona）](entries/Persona.md)
-- [碎片（Fragment）](entries/Fragment.md)
-
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [伪主体（Fauxmain）](/entries/Fauxmain.md)
+- [人格面具（Persona）](/entries/Persona.md)
+- [碎片（Fragment）](/entries/Fragment.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [主体（Main）](/entries/Main.md)
+- [管理者（Admin）](/entries/Admin.md)
+- [核心（Core）](/entries/Core.md)
 ## 参考与延伸阅读
 
 [^soulbondwiki]: Soulbonding Wiki. 2021. “Soulbond.” [https://soulbonding.fandom.com/wiki/Soulbond.](https://soulbonding.fandom.com/wiki/Soulbond.)

--- a/entries/Split-2016-DID-Representation.md
+++ b/entries/Split-2016-DID-Representation.md
@@ -1,6 +1,6 @@
 ---
 title: 《分裂》（Split, 2016）中的 DID 形象分析
-tags: [虚拟角色与文学影视作品]
+tags: [解离性身份障碍 DID, 分裂, 2016, 角色设定, 视觉与声音语言, 创伤背景, 基础概念, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -28,6 +28,16 @@ updated: 2025-10-03
 - [迫害者（Persecutor）](entries/Persecutor.md)
 - [创伤（Trauma）](entries/Trauma.md)
 
+## 相关条目
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](/entries/Fight-Club-1999-Identity-Metaphor.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Spontaneous.md
+++ b/entries/Spontaneous.md
@@ -1,6 +1,6 @@
 ---
 title: 自发型（Spontaneous）
-tags: [系统角色与类型]
+tags: [创伤, 系统角色与类型, 自发型, 自然演化, 灵性或冥想实践, 创意与认知探索, 与灵性认同的交集, 自我照护]
 updated: 2025-10-03
 ---
 
@@ -42,3 +42,14 @@ updated: 2025-10-03
 - [混合型（Mixed）](entries/Emmengard-Classification.md#混合型mixed)
 - [系魂（Soulbond）](entries/Soulbond.md)
 - [图帕（Tulpa）](entries/Tulpa.md)
+
+## 相关条目
+
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [特殊认同（Alterhuman）](/entries/Alterhuman.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [主体（Main）](/entries/Main.md)
+- [成员（Alter）](/entries/Alter.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Stress-Response.md
+++ b/entries/Stress-Response.md
@@ -1,6 +1,6 @@
 ---
 title: 应激反应（Stress Response）
-tags: [系统体验与机制]
+tags: [应激反应, 躯体反应, 解离加剧, 成员切换, 情境评估, 外部支持, 系统体验与机制, 复盘学习]
 updated: 2025-10-03
 ---
 
@@ -37,6 +37,16 @@ Stress Response、压力反应、战斗或逃跑反应
 
 反复或长期的创伤压力会让 HPA 轴失调，导致系统在安全情境下仍出现强烈应激反应。对于解离性身份障碍与复杂性创伤后压力症候群，治疗通常需先建立稳定化技能，再处理创伤记忆[^应激反应-2][^应激反应-3]。
 
+## 相关条目
+
+- [意识修改（Consciousness Modification）](/entries/Consciousness-Modification.md)
+- [封存（Sequestration）](/entries/Sequestration.md)
+- [存在感（Sense of Presence）](/entries/Sense-Of-Presence.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [独有记忆（Exomemory）](/entries/Exomemory.md)
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [记忆屏蔽（Memory Shielding）](/entries/Memory-Shielding.md)
+- [非我感（Depersonalization）](/entries/Depersonalization.md)
 ## 参考资料
 
 [^应激反应-1]: McEwen, B. S. (2007). Physiology and neurobiology of stress and adaptation: central role of the brain. _Physiological Reviews, 87_(3), 873-904.

--- a/entries/Switch.md
+++ b/entries/Switch.md
@@ -1,6 +1,6 @@
 ---
 title: 切换（Switch）
-tags: [系统体验与机制]
+tags: [定义与同义词, 切换, 交替, 主要特征, 社群与临床语境, 常见误区, 系统体验与机制, 实务建议]
 updated: 2025-10-03
 ---
 
@@ -44,10 +44,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [前台（Front / Fronting）](entries/Front-Fronting.md)
-* [共前台（Co-fronting）](entries/Co-Fronting.md)
-* [解离（Dissociation）](entries/Dissociation.md)
-
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [偏重（Bias / Median）](/entries/Bias.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [系统（System）](/entries/System.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
 ## 参考与延伸阅读
 
 [^pluralpedia-switch]: Pluralpedia. (2024). [Switching](https://pluralpedia.org/w/Switching).

--- a/entries/Sybil-1976-Cultural-Prototype.md
+++ b/entries/Sybil-1976-Cultural-Prototype.md
@@ -1,6 +1,6 @@
 ---
 title: 《西比尔》（Sybil, 1976）与多重人格文化原型
-tags: [虚拟角色与文学影视作品]
+tags: [西比尔, 1976, 治疗联盟, 人格谱系, 整合结局, 基础概念, 作品中的治疗叙事, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -28,6 +28,16 @@ updated: 2025-10-03
 - [整合（Integration）](entries/Integration.md)
 - [创伤（Trauma）](entries/Trauma.md)
 
+## 相关条目
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/System-Roles.md
+++ b/entries/System-Roles.md
@@ -1,6 +1,6 @@
 ---
 title: 人格职能（System Roles）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 人格职能, 非刚性框架, 跨诊断应用, 结构性解离模型, 发展阶段成员, 与治疗协作, 社区用法与变体]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 [^steele2017]: Steele, K., Boon, S., & Van der Hart, O. (2017). *Treating trauma-related dissociation: A practical, integrative approach*. W. W. Norton & Company.
 [^brown2019]: Brown, N., & Van der Hart, O. (2019). Stabilization in the treatment of dissociative disorders. In K. L. Dell & A. J. Lawson (Eds.), *Dissociation and the Dissociative Disorders: Past, Present, Future* (pp. 483–499). Routledge.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+
+## 相关条目
+
+- [初始（Original）](/entries/Original.md)
+- [青少年意识体（Teen Part）](/entries/Teen.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [照顾者（Caregiver）](/entries/Caregiver.md)

--- a/entries/System.md
+++ b/entries/System.md
@@ -1,6 +1,6 @@
 ---
 title: 系统（System）
-tags: [系统体验与机制]
+tags: [解离性身份障碍 DID, 定义与同义词, 复数系统, 系统, 群体身份, 诊断关联, 系统体验与机制, 解离性身份障碍]
 updated: 2025-10-03
 ---
 
@@ -68,13 +68,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [成员（Alter）](entries/Alter.md)
-- [前台（Front / Fronting）](entries/Front-Fronting.md)
-- [切换（Switch）](entries/Switch.md)
-- [多意识体（Plurality）](entries/Plurality.md)
-
----
-
+- [多意识体（Plurality）](/entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](/entries/Plurality-Basics.md)
+- [切换（Switch）](/entries/Switch.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
 ## 参考与延伸阅读
 
 [pluralpedia-system]: Pluralpedia. (2024). [System](https://pluralpedia.org/w/System).

--- a/entries/Teen.md
+++ b/entries/Teen.md
@@ -1,6 +1,6 @@
 ---
 title: 青少年意识体（Teen Part）
-tags: [系统角色与类型]
+tags: [系统角色与类型, 青少年意识体, 身份探索, 社群参与, 桥梁角色, 技能导向, 情绪波动, 常见特征]
 updated: 2025-10-03
 ---
 
@@ -41,3 +41,14 @@ updated: 2025-10-03
 [^howell2011]: Howell, E. F. (2011). *The dissociative mind*. Routledge.
 [^isstd2011]: International Society for the Study of Trauma and Dissociation. (2011). *Guidelines for treating dissociative identity disorder in adults, third revision*. Journal of Trauma & Dissociation, 12(2), 115–187.
 [^thepluralassociation2021]: The Plural Association. (2021). *Community guidelines for plural well-being*. The Plural Association.
+
+## 相关条目
+
+- [照顾者（Caregiver）](/entries/Caregiver.md)
+- [执行者（Performer / Executive）](/entries/Performer-Executive.md)
+- [小孩意识体（Little / Child Part）](/entries/Little.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
+- [记忆持有者（Memory Holder）](/entries/Memory-Holder.md)
+- [迫害者（Persecutor）](/entries/Persecutor.md)
+- [保护者（Protector）](/entries/Protector.md)
+- [初始（Original）](/entries/Original.md)

--- a/entries/Three-Faces-Of-Eve-1957-Dissociation.md
+++ b/entries/Three-Faces-Of-Eve-1957-Dissociation.md
@@ -1,6 +1,6 @@
 ---
 title: 《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现
-tags: [虚拟角色与文学影视作品]
+tags: [三面夏娃, 1957, 人格分化, 表演风格, 治疗视角, 基础概念, 叙事与角色特色, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -28,6 +28,16 @@ updated: 2025-10-03
 - [整合（Integration）](entries/Integration.md)
 - [系统角色（System Roles）](entries/System-Roles.md)
 
+## 相关条目
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](/entries/United-States-Of-Tara-System-Daily-Life.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Touhou-Tulpa-Fandom.md
+++ b/entries/Touhou-Tulpa-Fandom.md
@@ -1,6 +1,6 @@
 ---
 title: 《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）
-tags: [虚拟角色与文学影视作品]
+tags: [角色共鸣, 文化解读, 界限意识, 创作扩展, 社群实践, 基础概念, 文化讨论, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [系魂（Soulbond）](entries/Soulbond.md)
 - [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
 
+## 相关条目
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](/entries/Madoka-Magica-Kyubey-Otherness.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](/entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](/entries/Lovecraft-Tulpa-Motifs.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](/entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](/entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+- [傀儡（Servitor）](/entries/Servitor.md)
+- [埃蒙加德分类法（Emmengard Classification）](/entries/Emmengard-Classification.md)
+- [头压（Head Pressure）](/entries/Head-Pressure.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Trauma.md
+++ b/entries/Trauma.md
@@ -1,6 +1,6 @@
 ---
 title: 创伤（Trauma）
-tags: [诊断与临床]
+tags: [创伤, 治疗支持, 定义与同义词, 精神创伤, 风险与保护因素, 鉴别诊断, 诊断与临床, 参考与延伸阅读]
 updated: 2025-10-03
 ---
 
@@ -83,14 +83,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-* [创伤后应激障碍（PTSD）](entries/PTSD.md)
-* [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
-* [解离性身份障碍（DID）](entries/DID.md)
-* [部分解离性身份障碍（PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
-* [闪回（Flashback）](entries/Flashback.md)
-
----
-
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](/entries/PTSD.md)
+- [闪回（Flashback）](/entries/Flashback.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](/entries/OCD.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [双相障碍（Bipolar Disorders）](/entries/Bipolar-Disorders.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](/entries/Narcissistic-Personality-Disorder-NPD.md)
+- [焦虑（Anxiety）](/entries/Anxiety.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
 ## 参考与延伸阅读
 
 1. WHO. (2019). *ICD-11 for Mortality and Morbidity Statistics*.

--- a/entries/Trigger.md
+++ b/entries/Trigger.md
@@ -1,6 +1,6 @@
 ---
 title: 触发（Trigger）
-tags: [系统体验与机制]
+tags: [定义与同义词, 认知体验, 系统影响, 恢复方式, 触发点, 在部分社群讨论中也称 雷点, 刺激源, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -90,10 +90,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [闪回（Flashback）](entries/Flashback.md)
-- [自动驾驶（Autopilot）](entries/Autopilot.md)
-- [地面化技巧（Grounding）](entries/Grounding.md)
-
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](/entries/Xianyu-Theory-Niche-Classification.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [系统（System）](/entries/System.md)
 ## 参考与延伸阅读
 
 [^trigger-pluralpedia]: Pluralpedia. (n.d.). [Trigger](https://pluralpedia.org/w/Trigger).

--- a/entries/Tulpa.md
+++ b/entries/Tulpa.md
@@ -1,6 +1,6 @@
 ---
 title: 图帕（Tulpa）
-tags: [系统角色与类型]
+tags: [解离性身份障碍 DID, 系统角色与类型, 定义与同义词, 现代, 托帕, 实践者亦称其为系统伙伴, 实践中的, 内部同伴]
 updated: 2025-10-03
 ---
 
@@ -45,12 +45,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [宿主（Host）](entries/Host.md)
-- [傀儡（Servitor）](entries/Servitor.md)
-- [T 语（Tulpish）](entries/Tulpish.md)
-
----
-
+- [宿主（Host）](/entries/Host.md)
+- [内部自助者（Internal Self Helper，ISH）](/entries/Internal-Self-Helper-ISH.md)
+- [系统（System）](/entries/System.md)
+- [幻想伙伴（Imaginary Companion）](/entries/Imaginary-Companion.md)
+- [初始（Original）](/entries/Original.md)
+- [自发型（Spontaneous）](/entries/Spontaneous.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [人格职能（System Roles）](/entries/System-Roles.md)
 ## 参考与延伸阅读
 
 [^veissiere2016]: Veissière, S. P. L. (2016). Varieties of Tulpa experiences: Sentient imaginary friends, embodied joint-agents, and hypnotic social agents. *Anthropology of Consciousness, 27*(2), 213–239.

--- a/entries/Tulpish.md
+++ b/entries/Tulpish.md
@@ -1,6 +1,6 @@
 ---
 title: T 语（Tulpish）
-tags: [系统体验与机制]
+tags: [语, 核心特点, 诊断与临床, 建议与练习, 参考与延伸阅读, 使用场景, 概念包, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -52,12 +52,14 @@ T 语（Tulpish）是一种**非语言、符号化的沟通系统**，常见于�
 
 ## 相关条目
 
-* [头压（Head Pressure）](entries/Head-Pressure.md)
-* [冥想（Meditation）](entries/Meditation.md)
-* [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
-
----
-
+- [外投射（External Projection）](/entries/External-Projection.md)
+- [成员（Alter）](/entries/Alter.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [内视（Visualization / Imagination）](/entries/Visualization-Imagination.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
+- [超级破碎（Polyfragmented）](/entries/Polyfragmented.md)
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [投影（Projection）](/entries/Projection.md)
 ## 参考与延伸阅读
 
 [^tulpish-pluralpedia]: Pluralpedia. (n.d.). [Tulpish](https://pluralpedia.org/w/Tulpish).

--- a/entries/United-States-Of-Tara-System-Daily-Life.md
+++ b/entries/United-States-Of-Tara-System-Daily-Life.md
@@ -1,6 +1,6 @@
 ---
 title: 《我与梦露的一周》（The United States of Tara）中的系统家庭日常
-tags: [虚拟角色与文学影视作品]
+tags: [我与梦露的一周, 自我倡导, 系统协商, 家庭支持, 日常化视角, 基础概念, 社群讨论, 虚拟角色与文学影视作品]
 updated: 2025-10-03
 ---
 
@@ -27,6 +27,16 @@ updated: 2025-10-03
 - [共前台（Co-fronting）](entries/Co-Fronting.md)
 - [接地（Grounding）](entries/Grounding.md)
 
+## 相关条目
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](/entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](/entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](/entries/Sybil-1976-Cultural-Prototype.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](/entries/Mr-Robot-DID-Narrative.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](/entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](/entries/Dostoevsky-The-Double-Self-Division.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](/entries/Split-2016-DID-Representation.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](/entries/Another-Me-DID-Depictions.md)
 ## 参考资料
 
 - （待补充）

--- a/entries/Visualization-Imagination.md
+++ b/entries/Visualization-Imagination.md
@@ -1,6 +1,6 @@
 ---
 title: 内视（Visualization / Imagination）
-tags: [系统体验与机制]
+tags: [内视, 内在画面, 感官想象, 互动练习, 核心要素, 社群脉络, 实践提示, 系统体验与机制]
 updated: 2025-10-03
 ---
 
@@ -33,10 +33,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [投影（Projection）](entries/Projection.md)
-- [外投射（External Projection）](entries/External-Projection.md)
-- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
-
+- [外投射（External Projection）](/entries/External-Projection.md)
+- [投影（Projection）](/entries/Projection.md)
+- [T 语（Tulpish）](/entries/Tulpish.md)
+- [适应型（Adaptive）](/entries/Adaptive.md)
+- [前台（Front / Fronting）](/entries/Front-Fronting.md)
+- [解离（Dissociation）](/entries/Dissociation.md)
+- [侵入性思维（Intrusive Thoughts）](/entries/Intrusive-Thoughts.md)
+- [后台（Back / Being Back）](/entries/Back-Being-Back.md)
 ## 参考资料
 
 [^Visualization](https://pluralpedia.org/w/Visualization).

--- a/entries/Xianyu-Theory-Niche-Classification.md
+++ b/entries/Xianyu-Theory-Niche-Classification.md
@@ -1,6 +1,6 @@
 ---
 title: 弦羽理论生态位分类法（Xianyu Theory of Niche Classification）
-tags: [系统体验与机制]
+tags: [定义与同义词, 弦羽生态位模型, 弦羽分类法, 弦羽理论生态位分类法, 核心思想, 应用价值, 系统体验与机制, 局限性]
 updated: 2025-10-03
 ---
 
@@ -71,14 +71,14 @@ updated: 2025-10-03
 
 ## 相关条目
 
-- [创伤（Trauma）](entries/Trauma.md)
-- [系统（System）](entries/System.md)
-- [成员（Alter）](entries/Alter.md)
-- [Tulpa](entries/Tulpa.md)
-- [埃蒙加德环分类法](entries/Emongard-Ring-Classification.md)
-
----
-
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](/entries/Soul-Linked-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](/entries/Family-Systems-Xianyu.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](/entries/Mixed-Systems-Xianyu.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](/entries/Single-Class-Systems-Xianyu.md)
+- [内部空间（Headspace / Inner World）](/entries/Headspace-Inner-World.md)
+- [共前台（Co-fronting）](/entries/Co-Fronting.md)
+- [切换（Switch）](/entries/Switch.md)
+- [系统（System）](/entries/System.md)
 ## 参考与来源
 
 - 原文：弦羽系统提出的《弦羽理论生态位分类法》手稿

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyyaml
+python-frontmatter
+jieba
+nltk
+unidecode

--- a/tags.md
+++ b/tags.md
@@ -1,22 +1,1781 @@
 # 标签索引
 
+## 1957
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 1976
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 1999
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 2016
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+
+## BPD
+
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## CPTSD
+
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+
+## DPDR
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [解离（Dissociation）](entries/Dissociation.md)
+
+## DSM5TR要点
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## ICD11要点
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## NPD
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## SSD
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 三面夏娃
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 不
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 不可饶恕的她 对多重人格的叙事化呈现
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+
+## 与其他概念的比较
+
+- [偏重（Bias / Median）](entries/Bias.md)
+
+## 与图帕的区分
+
+- [傀儡（Servitor）](entries/Servitor.md)
+
+## 与多意识体概念的交叉
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 与完整成员的区别
+
+- [碎片（Fragment）](entries/Fragment.md)
+
+## 与宿主的并列
+
+- [初始（Original）](entries/Original.md)
+
+## 与幻觉的区分
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 与性别 年龄表达
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 与治疗协作
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+
+## 与灵性认同的交集
+
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+
+## 与碎片的关系
+
+- [核心（Core）](entries/Core.md)
+
+## 与迫害者转换
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 与迭代 重构等系统变化
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 临床关注点
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## 临床框架
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 主体
+
+- [主体（Main）](entries/Main.md)
+
+## 主体体验
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 主要取向
+
+- [冥想（Meditation）](entries/Meditation.md)
+
+## 主要特征
+
+- [偏重（Bias / Median）](entries/Bias.md)
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+- [切换（Switch）](entries/Switch.md)
+
+## 主要目的
+
+- [接地（Grounding）](entries/Grounding.md)
+
+## 主要解离元素
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+
+## 主观与流动性
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 主题解读
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 互动机制
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 互动练习
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 交替
+
+- [切换（Switch）](entries/Switch.md)
+
+## 亲属式系统
+
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+
+## 人格分化
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 人格职能
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+
+## 人格解体 现实解体障碍
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+
+## 人格谱系
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 人格镜像
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 人格面具
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 任务老化
+
+- [傀儡（Servitor）](entries/Servitor.md)
+
+## 伪主体
+
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+
+## 体验特征
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 体验特点
+
+- [投影（Projection）](entries/Projection.md)
+
+## 作品中的治疗叙事
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 使用原则
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 使用场景
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+
+## 侵入性思维
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+
+## 信息控制
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+
+## 偏重
+
+- [偏重（Bias / Median）](entries/Bias.md)
+
+## 傀儡
+
+- [傀儡（Servitor）](entries/Servitor.md)
+
+## 共享幻象
+
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+
+## 共享身体 缺乏共识
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 共创身份
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
+## 共前台
+
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+
+## 共存视角
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 共病处理
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## 关系动力
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 关键主题
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 关键议题
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
+## 其他特定解离性障碍
+
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+
+## 其他特定解离性障碍 OSDD
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+- [解离（Dissociation）](entries/Dissociation.md)
+
+## 内在画面
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 内视
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 内部养育者
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 内部协商
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 内部同伴
+
+- [图帕（Tulpa）](entries/Tulpa.md)
+
+## 内部界限
+
+- [成员（Alter）](entries/Alter.md)
+
+## 内部空间
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 内部空间 亦称 里空间
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 内部自助者
+
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+- [管理者（Admin）](entries/Admin.md)
+
+## 冥想练习
+
+- [冥想（Meditation）](entries/Meditation.md)
+
+## 分类与对比
+
+- [适应型（Adaptive）](entries/Adaptive.md)
+
+## 分裂
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+
+## 切换
+
+- [切换（Switch）](entries/Switch.md)
+
+## 创伤
+
+- [创伤（Trauma）](entries/Trauma.md)
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+- [适应型（Adaptive）](entries/Adaptive.md)
+
+## 创伤后应激反应障碍
+
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+
+## 创伤后应激障碍 PTSD
+
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 创伤提醒
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 创伤揭示
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 创伤背景
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+
+## 创伤触发
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+
+## 创伤记忆守护
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 创伤记忆泛滥
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 创作扩展
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 创意与认知探索
+
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+
+## 初始
+
+- [初始（Original）](entries/Original.md)
+
+## 刺激源
+
+- [触发（Trigger）](entries/Trigger.md)
+
+## 前台
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 前台与切换管理
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 前台守卫
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 前台安排
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 功能优先
+
+- [傀儡（Servitor）](entries/Servitor.md)
+
+## 功能分配
+
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+
+## 功能多样
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 功能定位
+
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+
+## 功能影响
+
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+
+## 功能性
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 功能性分离
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 功能整合
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 功能评估
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 动态协商
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 医源型系统
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 协商与边界
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 单一生态位系统
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+
+## 单一类系统
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+
+## 单核型系统
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+
+## 卡夫卡 变形记 与异化的身份解体
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+
+## 危机协调
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 参考与延伸阅读
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+- [创伤（Trauma）](entries/Trauma.md)
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 参见
+
+- [解离（Dissociation）](entries/Dissociation.md)
+
+## 参阅
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+
+## 双相障碍
+
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+
+## 双重人格
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+
+## 发展常见性
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 发展性补偿
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 发展路径
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 发展阶段成员
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+
+## 发展阶段特征
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 叙事不可靠
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 叙事与角色特色
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 叙事结构
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+
+## 叠加型系统
+
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 可塑性
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 可能风险
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 后台
+
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+
+## 和我 与
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 回归状态
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 在多意识体语境中的使用
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 在部分社群讨论中也称 雷点
+
+- [触发（Trigger）](entries/Trigger.md)
+
+## 地面化练习
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 埃蒙加德分类法
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 基础概念
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+- [傀儡（Servitor）](entries/Servitor.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+- [成员（Alter）](entries/Alter.md)
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+- [焦虑（Anxiety）](entries/Anxiety.md)
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 复合生态位系统
+
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 复数系统
+
+- [系统（System）](entries/System.md)
+
+## 复杂性创伤后应激障碍
+
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+
+## 复盘学习
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+
+## 外投射
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 外界沟通
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 外部支持
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 外部沟通
+
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 外部生活管理
+
+- [宿主（Host）](entries/Host.md)
+
+## 外部生活记忆的主轴
+
+- [初始（Original）](entries/Original.md)
+
+## 外部认知差异
+
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+
+## 多初始系统
+
+- [初始（Original）](entries/Original.md)
+
+## 多宿主共存
+
+- [宿主（Host）](entries/Host.md)
+
+## 多意识体
+
+- [多意识体（Plurality）](entries/Plurality.md)
+
+## 多意识体系统
+
+- [投影（Projection）](entries/Projection.md)
+
+## 多执行者协作
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 多维度构成
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 多维度组合
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 多轨思维
+
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 多重意识体基础
+
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+
+## 头压
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 头顶
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 契约机制
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+
+## 妄想代理人
+
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+
+## 媒体呈现
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 存在感
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 存在的你
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 孤独症谱系
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 守门人
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 安全地探索混合
+
+- [混合（Blending）](entries/Blending.md)
+
+## 安全导向
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 安全层级
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 安全提示
+
+- [核心（Core）](entries/Core.md)
+
+## 安全退出机制
+
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 定义与同义词
+
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+- [切换（Switch）](entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+- [创伤（Trauma）](entries/Trauma.md)
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+- [图帕（Tulpa）](entries/Tulpa.md)
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+- [系统（System）](entries/System.md)
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+- [触发（Trigger）](entries/Trigger.md)
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 定向障碍
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 实务建议
+
+- [偏重（Bias / Median）](entries/Bias.md)
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+- [冥想（Meditation）](entries/Meditation.md)
+- [切换（Switch）](entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+
 ## 实践与支持
 
 - [冥想（Meditation）](entries/Meditation.md)
 - [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
 - [接地（Grounding）](entries/Grounding.md)
 
+## 实践中的
+
+- [图帕（Tulpa）](entries/Tulpa.md)
+
+## 实践建议
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 实践提示
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 实践者亦称其为系统伙伴
+
+- [图帕（Tulpa）](entries/Tulpa.md)
+
+## 实际考量
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 家庭动力
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+
+## 家庭型系统
+
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+
+## 家庭支持
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+
+## 家族化系统
+
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+
+## 家族式系统
+
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+
+## 宿主
+
+- [宿主（Host）](entries/Host.md)
+
+## 宿主与前台的区别
+
+- [宿主（Host）](entries/Host.md)
+
+## 寄生性念头或幻觉
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 封存
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 尊重差异
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 小孩意识体
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 局限兴趣与行为
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 局限性
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 常见主题
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+
+## 常见例子
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 常见特征
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+- [照顾者（Caregiver）](entries/Caregiver.md)
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 常见练习
+
+- [接地（Grounding）](entries/Grounding.md)
+
+## 常见误区
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+- [偏重（Bias / Median）](entries/Bias.md)
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+- [冥想（Meditation）](entries/Meditation.md)
+- [切换（Switch）](entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+- [接地（Grounding）](entries/Grounding.md)
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 幻境 指系统成员在内在感知中共享
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 幻想伙伴
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 幻觉
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+
+## 应对策略
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 应激反应
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+
+## 应用价值
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 应用建议
+
+- [接地（Grounding）](entries/Grounding.md)
+
+## 康复与支持
+
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+
+## 建立信号
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+
+## 建立内部共识
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 建立阈值
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 建议与练习
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+
+## 弦羽分类法
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 弦羽理论生态位分类法
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 弦羽生态位模型
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 强烈情绪风暴
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 强迫性障碍
+
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+
+## 强迫症
+
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+
+## 形式分类
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 形成原因
+
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+
+## 影射
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 心理动力机制
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 心理教育与医患联盟
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 心理治疗
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 心理社会干预
+
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+
+## 心理防御
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 必要时寻求专业支持
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 恢复方式
+
+- [触发（Trigger）](entries/Trigger.md)
+
+## 情境示例
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 情境评估
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+
+## 情感投射
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
+## 情感空白
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+
+## 情感表达不能
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+
+## 情感调节能力
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 情感难言症
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+
+## 情感需求强烈
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 情绪与感官的分离
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 情绪与认知
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## 情绪与记忆激活
+
+- [混合（Blending）](entries/Blending.md)
+
+## 情绪共鸣
+
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 情绪分隔
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 情绪同频
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+
+## 情绪波动
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 情绪调节
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 情绪负荷较高
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 意识修改
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 意识共存
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 意象法实施
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 感官化反馈
+
+- [投影（Projection）](entries/Projection.md)
+
+## 感官想象
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 感官特征记录
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 感官线索
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+
 ## 感官调节
 
 - [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 感官调节策略
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 感知体验
+
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 感觉差异
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 慢性或急性压力
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 成员
+
+- [成员（Alter）](entries/Alter.md)
+
+## 成员切换
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+
+## 成年阶段
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 成长空间
+
+- [核心（Core）](entries/Core.md)
+
+## 我与梦露的一周
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+
+## 托帕
+
+- [图帕（Tulpa）](entries/Tulpa.md)
+
+## 执行功能整合
+
+- [主体（Main）](entries/Main.md)
+
+## 执行者
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 技能导向
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 技能强化
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 技能或知识保管
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 技能训练
+
+- [整合（Integration）](entries/Integration.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 抑郁期
+
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+
+## 抑郁障碍
+
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+
+## 投射方向
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 投影
+
+- [投影（Projection）](entries/Projection.md)
+
+## 持续性差异
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 持续时间
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 接地
+
+- [接地（Grounding）](entries/Grounding.md)
+
+## 控制权
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 搏击俱乐部
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 支持性空间
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 支持策略
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 支援策略
+
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 教育与环境调适
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 教育支持
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 整合
+
+- [整合（Integration）](entries/Integration.md)
+- [融合（Fusion）](entries/Fusion.md)
+- [迭代（Iteration）](entries/Iteration.md)
+
+## 整合结局
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 文化差异
+
+- [幻想伙伴（Imaginary Companion）](entries/Imaginary-Companion.md)
+
+## 文化挪用讨论
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 文化解读
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 文化讨论
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 无等级结构
+
+- [埃蒙加德分类法（Emmengard Classification）](entries/Emmengard-Classification.md)
+
+## 日常化视角
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+
+## 日常照护
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 早期干预
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 时间感差异
+
+- [小孩意识体（Little / Child Part）](entries/Little.md)
+
+## 时间敏感性
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 易感因素
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 本词条为消歧义页面
+
+- [解离（Dissociation）](entries/Dissociation.md)
+
+## 术语差异
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 术语来源
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 权限
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 权限矩阵
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 来源
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+- [谵妄（Delirium）](entries/Delirium.md)
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 来源背景
+
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+
+## 核心
+
+- [核心（Core）](entries/Core.md)
+
+## 核心思想
+
+- [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
+
+## 核心意象
+
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 核心构成要素
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 核心概念
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 核心特征
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+- [冥想（Meditation）](entries/Meditation.md)
+- [接地（Grounding）](entries/Grounding.md)
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 核心特点
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+
+## 核心要素
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 核心迁移
+
+- [核心（Core）](entries/Core.md)
+
+## 桥梁角色
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 概念包
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+
+## 概念演化
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+
+## 沟通与仲裁
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 沟通与边界
+
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 沟通习惯
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 沟通协作
+
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+- [宿主（Host）](entries/Host.md)
+- [成员（Alter）](entries/Alter.md)
+- [管理者（Admin）](entries/Admin.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 沟通技巧
+
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+
+## 沟通策略
+
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+
+## 治疗与支持
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## 治疗协作
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 治疗合作
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 治疗支持
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+- [创伤（Trauma）](entries/Trauma.md)
+
+## 治疗联盟
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 治疗视角
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 注意力不足
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 注意力缺陷多动障碍 ADHD
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 洛夫克拉夫特作品中的 心灵造物 与
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 混合
+
+- [混合（Blending）](entries/Blending.md)
+
+## 混合型系统
+
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 混合特征
+
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+
+## 渐进尝试
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 渐进训练
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+
+## 演化视角
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+
+## 潜在功能
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 灵性中介系统
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 灵性或冥想实践
+
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+
+## 灵活性
+
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 灵魂联结系统
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 焦虑
+
+- [焦虑（Anxiety）](entries/Anxiety.md)
+
+## 照顾者
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 物质影响
+
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 特征
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+- [家族式系统（Family Systems, Xianyu Theory）](entries/Family-Systems-Xianyu.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 状态转换
+
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+
+## 独有记忆
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 独特性
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 独立性
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 独立访问的心象环境
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 环境扫描
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 环境熟悉度
+
+- [混合（Blending）](entries/Blending.md)
+
+## 环境评估
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 现代
+
+- [图帕（Tulpa）](entries/Tulpa.md)
+
+## 现实与虚构的模糊
+
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+
+## 现实边界
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
+## 现象特征
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 理论模型
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+
+## 生命周期事件
+
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 生态位定位
+
+- [单一类系统（Single-Class Systems, Xianyu Theory）](entries/Single-Class-Systems-Xianyu.md)
+- [混合型系统（Mixed Systems, Xianyu Theory）](entries/Mixed-Systems-Xianyu.md)
+
+## 生理与神经系统
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## 生理状态
+
+- [存在感（Sense of Presence）](entries/Sense-Of-Presence.md)
+
+## 用于互动
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 用于区分不同语境下的
+
+- [解离（Dissociation）](entries/Dissociation.md)
+
+## 界限与合作
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## 界限与日常结构
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 界限意识
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 界限设定
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 病理性解离
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 病程与共病
+
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+
+## 的边界 初音未来现象
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
+## 目标多样性
+
+- [整合（Integration）](entries/Integration.md)
+
+## 目的多样
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
 
 ## 相关概念与理论
 
 - [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
 
+## 知识与具现
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 知识传播
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 研究现状
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
+
+## 碎片
+
+- [碎片（Fragment）](entries/Fragment.md)
+
+## 社会与文化考量
+
+- [整合（Integration）](entries/Integration.md)
+
+## 社会交流
+
+- [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
+
+## 社会文化
+
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+
+## 社会模型
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 社会疏离
+
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 社会角色期望
+
+- [主体（Main）](entries/Main.md)
+
+## 社区文化
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+- [成员（Alter）](entries/Alter.md)
+- [管理者（Admin）](entries/Admin.md)
+
+## 社区用法与变体
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+- [初始（Original）](entries/Original.md)
+
+## 社群与临床语境
+
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+- [切换（Switch）](entries/Switch.md)
+- [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+
 ## 社群与文化
 
 - [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 社群功能
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 社群参与
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 社群反响
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 社群实践
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 社群经验
+
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 社群脉络
+
+- [内视（Visualization / Imagination）](entries/Visualization-Imagination.md)
+
+## 社群解读
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+
+## 社群讨论
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+
+## 社群语境
+
+- [偏重（Bias / Median）](entries/Bias.md)
+- [投影（Projection）](entries/Projection.md)
+
+## 神经多样性
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 神经影像观察
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 神经生物学
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 神经生物学基础
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 神经生物学视角
+
+- [碎片（Fragment）](entries/Fragment.md)
+
+## 神经生理指标
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 神经网络视角
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 神经退行性疾病
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 积极效应
+
+- [融合（Fusion）](entries/Fusion.md)
+
+## 稳定化与接地技巧
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 稳定性与安全感
+
+- [整合（Integration）](entries/Integration.md)
+
+## 空间定位
+
+- [投影（Projection）](entries/Projection.md)
+
+## 策略价值
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 策略灵活
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 管理者
+
+- [管理者（Admin）](entries/Admin.md)
+
+## 精神分裂症
+
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+
+## 精神创伤
+
+- [创伤（Trauma）](entries/Trauma.md)
+
+## 精神病性症状
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## 精神病性障碍
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 系统
+
+- [系统（System）](entries/System.md)
+
+## 系统体验
+
+- [谵妄（Delirium）](entries/Delirium.md)
 
 ## 系统体验与机制
 
@@ -43,6 +1802,7 @@
 - [弦羽理论生态位分类法（Xianyu Theory of Niche Classification）](entries/Xianyu-Theory-Niche-Classification.md)
 - [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
 - [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+- [成员（Alter）](entries/Alter.md)
 - [投影（Projection）](entries/Projection.md)
 - [整合（Integration）](entries/Integration.md)
 - [权限（Permissions）](entries/Permissions.md)
@@ -59,9 +1819,32 @@
 - [躯体认同（Body Ownership）](entries/Body-Ownership.md)
 - [迭代（Iteration）](entries/Iteration.md)
 - [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+- [适应型（Adaptive）](entries/Adaptive.md)
 - [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
 - [重构（Reconstruction）](entries/Reconstruction.md)
 - [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 系统内空窗
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 系统协商
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 系统影响
+
+- [碎片（Fragment）](entries/Fragment.md)
+- [触发（Trigger）](entries/Trigger.md)
+
+## 系统管理
+
+- [管理者（Admin）](entries/Admin.md)
+
+## 系统自检
+
+- [医源型系统（Iatrogenic System）](entries/Iatrogenic-System.md)
 
 ## 系统角色与类型
 
@@ -96,6 +1879,178 @@
 - [适应型（Adaptive）](entries/Adaptive.md)
 - [青少年意识体（Teen Part）](entries/Teen.md)
 
+## 系统适用的自助建议
+
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+
+## 系魂
+
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 系魂型系统
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 紧急协议
+
+- [权限（Permissions）](entries/Permissions.md)
+
+## 结构性解离
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+
+## 结构性解离模型
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+- [碎片（Fragment）](entries/Fragment.md)
+
+## 结构性解离理论
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 结构性解离视角
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 结构性资源差距
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 结构整合
+
+- [整合（Integration）](entries/Integration.md)
+
+## 维度划分
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 综合照护
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 综合策略
+
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+
+## 群体身份
+
+- [系统（System）](entries/System.md)
+
+## 职责划分
+
+- [主体（Main）](entries/Main.md)
+
+## 自动驾驶
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 自发型
+
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+
+## 自恋型人格障碍
+
+- [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
+
+## 自恋或表演型人格障碍
+
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 自我与他者边界
+
+- [洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）](entries/Lovecraft-Tulpa-Motifs.md)
+
+## 自我倡导
+
+- [《我与梦露的一周》（The United States of Tara）中的系统家庭日常](entries/United-States-Of-Tara-System-Daily-Life.md)
+
+## 自我决定权
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 自我定向障碍
+
+- [定向障碍（Disorientation）](entries/Disorientation.md)
+
+## 自我对峙
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 自我感强度
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 自我照护
+
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+- [适应型（Adaptive）](entries/Adaptive.md)
+
+## 自我照顾与界限
+
+- [宿主（Host）](entries/Host.md)
+
+## 自我监控过度
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+
+## 自我监测
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 自我评估
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 自然演化
+
+- [自发型（Spontaneous）](entries/Spontaneous.md)
+
+## 自评工具
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 自责与羞耻
+
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 自闭症谱系
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+
+## 自陈量表
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+
+## 药物与治疗
+
+- [侵入性思维（Intrusive Thoughts）](entries/Intrusive-Thoughts.md)
+
+## 药物或物质影响
+
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+
+## 药物治疗
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 药物策略
+
+- [谵妄（Delirium）](entries/Delirium.md)
+
+## 莉莉丝
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 虚拟偶像与
+
+- [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
+
 ## 虚拟角色与文学影视作品
 
 - [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
@@ -115,10 +2070,289 @@
 - [虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）](entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md)
 - [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
 
+## 融合 整合
+
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 融合与整合
+
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 融合后的反弹
+
+- [迭代（Iteration）](entries/Iteration.md)
+
+## 行为
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## 行为与心理干预
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 行为变化
+
+- [焦虑（Anxiety）](entries/Anxiety.md)
+
+## 行为持续但意识缺席
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 行为特征
+
+- [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
+
+## 表演风格
+
+- [《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现](entries/Three-Faces-Of-Eve-1957-Dissociation.md)
+
+## 西比尔
+
+- [《西比尔》（Sybil, 1976）与多重人格文化原型](entries/Sybil-1976-Cultural-Prototype.md)
+
+## 观众解读
+
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+
+## 视觉与声音语言
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+
+## 视觉化呈现
+
+- [投影（Projection）](entries/Projection.md)
+
+## 角色共鸣
+
+- [《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）](entries/Touhou-Tulpa-Fandom.md)
+
+## 角色分化
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 角色可塑性
+
+- [初始（Original）](entries/Original.md)
+
+## 角色可转移
+
+- [宿主（Host）](entries/Host.md)
+
+## 角色替换
+
+- [意识修改（Consciousness Modification）](entries/Consciousness-Modification.md)
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 角色流动性
+
+- [主体（Main）](entries/Main.md)
+
+## 角色特征
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+
+## 角色设定
+
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+
+## 解体与重构主题
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 解体意象
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+
+## 解离
+
+- [功能性分离（Functional Dissociation）](entries/Functional-Dissociation.md)
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+- [解离（Dissociation）](entries/Dissociation.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 解离加剧
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+
+## 解离性发作 离解症
+
+- [谵妄（Delirium）](entries/Delirium.md)
+
+## 解离性漫游
+
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+
+## 解离性身份障碍
+
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+- [系统（System）](entries/System.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+
+## 解离性身份障碍 DID
+
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+- [《分裂》（Split, 2016）中的 DID 形象分析](entries/Split-2016-DID-Representation.md)
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+- [图帕（Tulpa）](entries/Tulpa.md)
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+- [混合（Blending）](entries/Blending.md)
+- [系统（System）](entries/System.md)
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+- [解离（Dissociation）](entries/Dissociation.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 解离性遗忘
+
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+
+## 解离性障碍
+
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 解离相关象征
+
+- [《妄想代理人》（Paranoia Agent）与集体意识的具象化](entries/Paranoia-Agent-Collective-Consciousness.md)
+
+## 解离研究关联
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 解离谱系观点
+
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+
+## 触发与过载
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 触发因素
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 触发场景
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 触发点
+
+- [触发（Trigger）](entries/Trigger.md)
+
+## 认知与情绪
+
+- [焦虑（Anxiety）](entries/Anxiety.md)
+
+## 认知与社会因素
+
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+
+## 认知体验
+
+- [触发（Trigger）](entries/Trigger.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 记录工具
+
+- [前台（Front / Fronting）](entries/Front-Fronting.md)
+
+## 记录建议
+
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+
+## 记录方式
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 记录日志
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 记录管理
+
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 记录者 观察者
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 记录触发因素
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 记忆屏蔽
+
+- [记忆屏蔽（Memory Shielding）](entries/Memory-Shielding.md)
+
+## 记忆差异
+
+- [自动驾驶（Autopilot）](entries/Autopilot.md)
+
+## 记忆建构理论
+
+- [独有记忆（Exomemory）](entries/Exomemory.md)
+
+## 记忆持有者
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 记忆断片
+
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+
+## 记忆管理
+
+- [管理者（Admin）](entries/Admin.md)
+
+## 记忆缺失的程度
+
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 记忆范围集中
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+
+## 评估与治疗
+
+- [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+
+## 评估与鉴别
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 评估工具
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 评估风险
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 识别与评估
+
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 识别方法
+
+- [碎片（Fragment）](entries/Fragment.md)
+
 ## 诊断与临床
 
+- [ANP-EP 模型（Apparently Normal Part–Emotional Part Model）](entries/Apparently-Normal-Part-Emotional-Part-Model.md)
+- [T 语（Tulpish）](entries/Tulpish.md)
 - [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
-- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+- [偏重（Bias / Median）](entries/Bias.md)
+- [冥想（Meditation）](entries/Meditation.md)
 - [创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）](entries/PTSD.md)
 - [创伤（Trauma）](entries/Trauma.md)
 - [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
@@ -126,18 +2360,484 @@
 - [孤独症谱系（Autism Spectrum Disorder）](entries/Autism-Spectrum-Disorder.md)
 - [定向障碍（Disorientation）](entries/Disorientation.md)
 - [强迫症（Obsessive-Compulsive Disorder, OCD）](entries/OCD.md)
+- [成员（Alter）](entries/Alter.md)
 - [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+- [接地（Grounding）](entries/Grounding.md)
 - [注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）](entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md)
 - [焦虑（Anxiety）](entries/Anxiety.md)
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
 - [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
 - [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
 - [自恋型人格障碍（Narcissistic Personality Disorder，NPD）](entries/Narcissistic-Personality-Disorder-NPD.md)
 - [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
 - [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
 - [谵妄（Delirium）](entries/Delirium.md)
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
 - [躁狂（Mania）](entries/Mania.md)
 - [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
 - [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
 - [述情障碍（Alexithymia）](entries/Alexithymia.md)
+- [适应型（Adaptive）](entries/Adaptive.md)
 - [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
 - [闪回（Flashback）](entries/Flashback.md)
+
+## 诊断关联
+
+- [系统（System）](entries/System.md)
+
+## 诊断要点
+
+- [焦虑（Anxiety）](entries/Anxiety.md)
+- [精神分裂症（Schizophrenia，SC）](entries/Schizophrenia-SC.md)
+
+## 语
+
+- [T 语（Tulpish）](entries/Tulpish.md)
+
+## 语境差异
+
+- [主体（Main）](entries/Main.md)
+
+## 语言与叙事
+
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 语言断层
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+
+## 误区2
+
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 误区3
+
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 调节练习
+
+- [头压（Head Pressure）](entries/Head-Pressure.md)
+
+## 谱系中间者视角
+
+- [核心（Core）](entries/Core.md)
+
+## 谵妄
+
+- [谵妄（Delirium）](entries/Delirium.md)
+
+## 责任感强
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 资本主义批判
+
+- [《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻](entries/Fight-Club-1999-Identity-Metaphor.md)
+
+## 资源消耗
+
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+
+## 资源评估
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 起源
+
+- [人格面具（Persona）](entries/Persona.md)
+
+## 起源背景
+
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 起病时间
+
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 超级破碎
+
+- [超级破碎（Polyfragmented）](entries/Polyfragmented.md)
+
+## 跨标签协作
+
+- [神经多样性（Neurodiversity）](entries/Neurodiversity.md)
+
+## 跨系统互助
+
+- [照顾者（Caregiver）](entries/Caregiver.md)
+
+## 跨诊断应用
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+
+## 躁狂
+
+- [躁狂（Mania）](entries/Mania.md)
+
+## 躁狂 轻躁狂期
+
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+
+## 身份切换
+
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+
+## 身份协商
+
+- [核心（Core）](entries/Core.md)
+
+## 身份反转
+
+- [《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）](entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md)
+
+## 身份定位
+
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+
+## 身份形态
+
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+
+## 身份感与时间感模糊
+
+- [混合（Blending）](entries/Blending.md)
+
+## 身份持续性
+
+- [系魂（Soulbond）](entries/Soulbond.md)
+
+## 身份探索
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 身份相关的象征性体验
+
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 身份认可
+
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+
+## 身份认同
+
+- [《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）](entries/Another-Me-DID-Depictions.md)
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+
+## 身份认同议题
+
+- [初始（Original）](entries/Original.md)
+
+## 身体与感官练习
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+
+## 身体信号
+
+- [感官调节策略（Sensory Regulation Strategies）](entries/Sensory-Regulation-Strategies.md)
+
+## 身体创伤与身体异化
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 身体异化
+
+- [卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）](entries/Kafka-Metamorphosis-Identity-Dissolution.md)
+
+## 身体或动作的失控感
+
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 躯体与情绪症状
+
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+
+## 躯体化
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 躯体化障碍
+
+- [躯体化障碍（Somatic Symptom Disorder，SSD）](entries/Somatic-Symptom-Disorder-SSD.md)
+
+## 躯体反应
+
+- [应激反应（Stress Response）](entries/Stress-Response.md)
+- [焦虑（Anxiety）](entries/Anxiety.md)
+
+## 躯体疾病
+
+- [抑郁障碍（Depressive Disorders）](entries/Depressive-Disorders.md)
+
+## 躯体认同
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 转化为保护者
+
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 轮班机制
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 辅量资料
+
+- [病理性解离（Pathological Dissociation）](entries/Pathological-Dissociation.md)
+
+## 边界主题
+
+- [《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）](entries/Nonexistent-You-And-Me-Tulpa-Lilith.md)
+
+## 边界感知敏锐
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 边界管理
+
+- [傀儡（Servitor）](entries/Servitor.md)
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+
+## 边界设定
+
+- [外投射（External Projection）](entries/External-Projection.md)
+
+## 边缘性人格障碍
+
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+- [边缘性人格障碍（Borderline Personality Disorder，BPD）](entries/Borderline-Personality-Disorder-BPD.md)
+
+## 连续谱
+
+- [独立性（Independence）](entries/Independence.md)
+
+## 迫害者
+
+- [记忆持有者（Memory Holder）](entries/Memory-Holder.md)
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 迭代
+
+- [迭代（Iteration）](entries/Iteration.md)
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 述情障碍
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+
+## 退行
+
+- [退行（Regression in Psychology）](entries/Regression-In-Psychology.md)
+
+## 适应型
+
+- [适应型（Adaptive）](entries/Adaptive.md)
+
+## 适用场景
+
+- [傀儡（Servitor）](entries/Servitor.md)
+
+## 通灵型系统
+
+- [系魂型系统（Soul-Linked Systems, Xianyu Theory）](entries/Soul-Linked-Systems-Xianyu.md)
+
+## 遗忘模式
+
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+
+## 部分
+
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+
+## 部分社群用法
+
+- [共前台（Co-fronting）](entries/Co-Fronting.md)
+
+## 部分解离性身份障碍
+
+- [解离性身份障碍（Dissociative Identity Disorder，DID）](entries/DID.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 醉酒解离
+
+- [醉酒解离（Alcohol-Induced Dissociation）](entries/Alcohol-Induced-Dissociation.md)
+
+## 里空间
+
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+
+## 重度抑郁或双相障碍
+
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+
+## 重度抑郁或双相障碍发作
+
+- [谵妄（Delirium）](entries/Delirium.md)
+
+## 重度抑郁障碍或双相障碍
+
+- [人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）](entries/Depersonalization-Derealization-Disorder-DPDR.md)
+
+## 重建内部沟通
+
+- [迭代（Iteration）](entries/Iteration.md)
+
+## 重构
+
+- [迭代（Iteration）](entries/Iteration.md)
+- [重构（Reconstruction）](entries/Reconstruction.md)
+
+## 重要说明
+
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 鉴别诊断
+
+- [创伤（Trauma）](entries/Trauma.md)
+- [双相障碍（Bipolar Disorders）](entries/Bipolar-Disorders.md)
+- [焦虑（Anxiety）](entries/Anxiety.md)
+
+## 镜像对手
+
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 长期整合目标的弹性
+
+- [迭代（Iteration）](entries/Iteration.md)
+
+## 闪回
+
+- [闪回（Flashback）](entries/Flashback.md)
+
+## 防御机制
+
+- [述情障碍（Alexithymia）](entries/Alexithymia.md)
+- [适应型（Adaptive）](entries/Adaptive.md)
+
+## 防御者
+
+- [保护者（Protector）](entries/Protector.md)
+
+## 阶段化创伤治疗
+
+- [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)
+
+## 阶段化治疗
+
+- [整合（Integration）](entries/Integration.md)
+- [混合（Blending）](entries/Blending.md)
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 阶段性认同
+
+- [躯体认同（Body Ownership）](entries/Body-Ownership.md)
+
+## 陀思妥耶夫斯基 双重人格
+
+- [陀思妥耶夫斯基《双重人格》（The Double）与自我分裂](entries/Dostoevsky-The-Double-Self-Division.md)
+
+## 隐形人
+
+- [《隐形人》（Mr. Robot）中的人格分裂叙事](entries/Mr-Robot-DID-Narrative.md)
+
+## 难以信任支持
+
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 青少年意识体
+
+- [青少年意识体（Teen Part）](entries/Teen.md)
+
+## 非典型解离障碍
+
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+
+## 非刚性框架
+
+- [人格职能（System Roles）](entries/System-Roles.md)
+
+## 非我感
+
+- [非我感（Depersonalization）](entries/Depersonalization.md)
+
+## 非正式
+
+- [其他特定解离性障碍（OSDD）](entries/OSDD.md)
+
+## 非永久解决方案
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 非病理化视角
+
+- [多意识体（Plurality）](entries/Plurality.md)
+- [多重意识体基础（Plurality Basics）](entries/Plurality-Basics.md)
+
+## 非药物干预
+
+- [谵妄（Delirium）](entries/Delirium.md)
+
+## 预设沟通渠道
+
+- [意识共存（Co-consciousness）](entries/Co-Consciousness.md)
+
+## 风险与保护因素
+
+- [创伤（Trauma）](entries/Trauma.md)
+
+## 风险与注意事项
+
+- [冥想（Meditation）](entries/Meditation.md)
+
+## 风险因素
+
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+
+## 风险应对
+
+- [主体（Main）](entries/Main.md)
+- [人格面具（Persona）](entries/Persona.md)
+- [伪主体（Fauxmain）](entries/Fauxmain.md)
+- [内部自助者（Internal Self Helper，ISH）](entries/Internal-Self-Helper-ISH.md)
+- [后台（Back / Being Back）](entries/Back-Being-Back.md)
+- [特殊认同（Alterhuman）](entries/Alterhuman.md)
+- [独立性（Independence）](entries/Independence.md)
+- [碎片（Fragment）](entries/Fragment.md)
+- [管理者（Admin）](entries/Admin.md)
+- [系魂（Soulbond）](entries/Soulbond.md)
+- [部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）](entries/Partial-Dissociative-Identity-Disorder-PDID.md)
+
+## 风险评估
+
+- [解离性遗忘（Dissociative Amnesia，DA）](entries/Dissociative-Amnesia-DA.md)
+
+## 验证其意图
+
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 高功能导向
+
+- [执行者（Performer / Executive）](entries/Performer-Executive.md)
+
+## 高危冲动或自伤意图
+
+- [封存（Sequestration）](entries/Sequestration.md)
+
+## 高压或创伤复燃
+
+- [迭代（Iteration）](entries/Iteration.md)
+
+## 高层视角
+
+- [守门人（Gatekeeper）](entries/Gatekeeper.md)
+
+## 高度警觉
+
+- [迫害者（Persecutor）](entries/Persecutor.md)
+
+## 魔法少女小圆 中的丘比与契约式 他者
+
+- [《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）](entries/Madoka-Magica-Kyubey-Otherness.md)

--- a/tools/retag_and_related.py
+++ b/tools/retag_and_related.py
@@ -1,0 +1,713 @@
+"""
+retag_and_related.py
+
+批量维护词条标签与“相关条目”区块。
+
+功能：
+1. 解析 entries/**/*.md Frontmatter 与正文。
+2. 基于标题、定义、同义词等信息重新生成归一化标签。
+3. 根据标签重叠与语义相似度计算相关条目，更新“## 相关条目”区块。
+4. 提供 --dry-run / --limit / --only / --since 参数控制执行范围。
+
+依赖：pyyaml、python-frontmatter、jieba、nltk、unidecode。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+from collections import Counter, OrderedDict, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, MutableMapping, Sequence, Tuple
+
+try:
+    import frontmatter  # type: ignore
+except ImportError:  # pragma: no cover - 依赖缺失时启用简易解析
+    frontmatter = None
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - 依赖缺失
+    yaml = None
+
+try:
+    import jieba  # type: ignore
+    import jieba.analyse  # type: ignore
+except ImportError:  # pragma: no cover
+    jieba = None
+    jieba_analyse = None
+else:  # pragma: no cover - 依赖存在
+    jieba_analyse = jieba.analyse
+
+try:
+    from nltk.stem import PorterStemmer  # type: ignore
+except ImportError:  # pragma: no cover
+    class PorterStemmer:  # type: ignore
+        def stem(self, word: str) -> str:
+            return word
+
+try:
+    from unidecode import unidecode  # type: ignore
+except ImportError:  # pragma: no cover
+    def unidecode(text: str) -> str:  # type: ignore
+        return text
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRIES_DIR = ROOT / "entries"
+
+SYN_MAP = {
+    "多重人格": "多重意识体",
+    "多重人格障碍": "多重意识体",
+    "多重系统": "多重意识体",
+    "多重意识体系统": "多重意识体",
+    "分离性身份障碍": "解离性身份障碍",
+    "分离性身份辨识障碍": "解离性身份障碍",
+    "解离症状": "解离",
+    "解离状态": "解离",
+    "解离体验": "解离",
+    "心理创伤": "创伤",
+    "创伤事件": "创伤",
+    "复杂创伤": "创伤",
+    "创伤后压力症候群": "创伤后应激障碍 PTSD",
+    "创伤后应激症候群": "创伤后应激障碍 PTSD",
+    "创伤后应激障碍": "创伤后应激障碍 PTSD",
+    "创伤后应激障碍 (PTSD)": "创伤后应激障碍 PTSD",
+    "PTSD": "创伤后应激障碍 PTSD",
+    "ptsd": "创伤后应激障碍 PTSD",
+    "DID": "解离性身份障碍 DID",
+    "did": "解离性身份障碍 DID",
+    "osdd": "其他特定解离性障碍 OSDD",
+    "OSDD": "其他特定解离性障碍 OSDD",
+    "admin": "管理者",
+    "Admin": "管理者",
+    "adaptive": "适应型",
+    "Adaptive": "适应型",
+    "内在世界": "系统内空间",
+    "内在空间": "系统内空间",
+    "守门者": "守门人",
+    "守门员": "守门人",
+    "保护者": "防御者",
+    "守护者": "防御者",
+    "融合": "整合",
+    "治疗": "治疗支持",
+    "支持网络": "社会支持",
+    "安全计划": "安全策略",
+    "地面化": "地面化练习",
+    "冥想": "冥想练习",
+    "冥想练习": "冥想",
+    "正念冥想": "正念",
+    "正念训练": "正念",
+    "述情障碍": "述情障碍",
+    "述情困难": "述情障碍",
+    "alexithymia": "述情障碍",
+    "dissociation": "解离",
+    "anxiety": "焦虑",
+    "alcohol-induced": "醉酒解离",
+    "alcohol induced": "醉酒解离",
+    "another": "解离性身份障碍 DID",
+    "adhd": "注意力缺陷多动障碍 ADHD",
+    "ADHD": "注意力缺陷多动障碍 ADHD",
+    "注意缺陷多动障碍": "注意力缺陷多动障碍 ADHD",
+    "注意缺陷多动症": "注意力缺陷多动障碍 ADHD",
+    "形成背景": "创伤",
+    "创伤经历": "创伤",
+    "常见体验": "系统体验与机制",
+    "支持与自我照顾建议": "自我照护",
+    "风险提示": "风险应对",
+    "风险应对": "风险应对",
+    "跨语境沟通": "沟通协作",
+    "知识与访问优势": "记忆管理",
+    "社群用法": "社区文化",
+    "沟通工具": "沟通协作",
+    "统称概念": "身份认同",
+    "特殊认同": "身份认同",
+    "认同范围": "身份认同",
+    "自我照护": "自我照护",
+    "社会文化因素": "社会文化",
+    "表现": "媒体呈现",
+    "悬疑结构": "叙事结构",
+    "身份认同": "身份认同",
+    "外部介入": "治疗支持",
+    "双重人格 类作品的": "媒体呈现",
+    "概述": "基础概念",
+    "模型": "理论模型",
+    "模型概述": "理论模型",
+    "鉴别": "诊断与临床",
+    "结构性解离的层级": "结构性解离",
+    "社群与系统语境下的讨论": "社区文化",
+    "是否存在摄入": "物质影响",
+    "感知离散化": "感知体验",
+    "运动与语言迟缓": "躯体化",
+    "角色间的交叠": "内部角色互动",
+    "沟通目的": "沟通协作",
+    "防御与角色分化": "防御机制",
+    "躯体症状及慢性疾病": "躯体化",
+    "教育与家庭支持": "教育支持",
+    "多动 冲动": "行为特征",
+    "功能受损": "功能评估",
+    "领导者 系统组织者": "系统角色与类型",
+    "维持运作": "系统管理",
+    "社区语境": "社区文化",
+    "解离性诊断关联": "诊断与临床",
+    "与临床术语的区分": "诊断与临床",
+    "沟通协调": "沟通协作",
+    "处理方式不同": "应对策略",
+    "多来源解释": "身份认同",
+    "与性别 性倾向的区别": "身份认同",
+    "常见叙事模式": "叙事结构",
+    "评估重点": "诊断与临床",
+    "流动性": "系统体验与机制",
+    "功能分工": "系统角色与类型",
+    "意识特征": "系统体验与机制",
+    "语言敏感性": "沟通协作",
+    "外部披露": "沟通协作",
+    "同意与界限": "内部界限",
+    "临床描述": "诊断与临床",
+    "与其他标签的关系": "分类与对比",
+    "核心要点": "基础概念",
+    "多意识体视角": "媒体呈现",
+    "关联词条": "媒体呈现",
+}
+
+STOP_TAGS = {
+    "简介",
+    "定义",
+    "参考",
+    "参考资料",
+    "参考文献",
+    "相关条目",
+    "模板",
+    "条目",
+    "外部链接",
+    "目录",
+    "更新",
+    "同义词",
+    "延伸阅读",
+    "注释",
+}
+
+MIN_TAGS = 3
+MAX_TAGS = 8
+
+ALLOWED_ASCII_TAGS = {
+    "DID",
+    "OSDD",
+    "PTSD",
+    "CPTSD",
+    "DPDR",
+    "ADHD",
+    "BPD",
+    "NPD",
+    "SSD",
+    "ANP",
+    "EP",
+}
+
+CHINESE_RE = re.compile(r"[\u4e00-\u9fff]")
+ASCII_RE = re.compile(r"[A-Za-z]")
+
+PRIMARY_TAG_PRIORITY = {
+    "多重意识体": 10,
+    "解离": 9,
+    "创伤": 9,
+    "解离性身份障碍 DID": 8,
+    "其他特定解离性障碍 OSDD": 8,
+    "创伤后应激障碍 PTSD": 8,
+    "系统体验": 7,
+    "系统角色与类型": 7,
+    "实践与支持": 6,
+    "治疗支持": 6,
+}
+
+REF_SECTION_RE = re.compile(
+    r"\n## (参考(资料|文献|来源)?|注释|外部链接)",
+    re.IGNORECASE,
+)
+
+RELATED_BLOCK_RE = re.compile(r"^## 相关条目\b.*?(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+
+ps = PorterStemmer()
+
+
+@dataclass
+class SimplePost:
+    metadata: MutableMapping[str, object]
+    order: List[str]
+    content: str
+
+
+@dataclass
+class PostRecord:
+    path: Path
+    title: str
+    tags: List[str]
+    tokens: Counter
+
+
+def _format_frontmatter_line(key: str, value: object) -> str:
+    if isinstance(value, list):
+        joined = ", ".join(str(v) for v in value)
+        return f"{key}: [{joined}]"
+    return f"{key}: {value}"
+
+
+def _simple_parse_frontmatter(text: str) -> Tuple[MutableMapping[str, object], List[str], str]:
+    if not text.startswith("---"):
+        return OrderedDict(), [], text
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", text, re.S)
+    if not match:
+        return OrderedDict(), [], text
+    fm_text = match.group(1)
+    body = text[match.end():]
+    if yaml is not None:
+        data = yaml.safe_load(fm_text) or {}
+        if not isinstance(data, dict):
+            data = {}
+        order = list(data.keys())
+        metadata = OrderedDict((k, data[k]) for k in order)
+    else:
+        metadata = OrderedDict()
+        order: List[str] = []
+        for raw_line in fm_text.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if value.startswith("[") and value.endswith("]"):
+                inner = value[1:-1].strip()
+                items = []
+                if inner:
+                    for part in inner.split(","):
+                        item = part.strip().strip('"\'')
+                        if item:
+                            items.append(item)
+                metadata[key] = items
+            else:
+                metadata[key] = value.strip('"\'')
+            order.append(key)
+    return metadata, order, body
+
+
+def _simple_load(path: Path) -> SimplePost:
+    raw = path.read_text(encoding="utf-8")
+    metadata, order, body = _simple_parse_frontmatter(raw)
+    return SimplePost(metadata=metadata, order=order, content=body)
+
+
+def _simple_dump(post: SimplePost) -> str:
+    lines = ["---"]
+    seen = set()
+    for key in post.order:
+        value = post.metadata.get(key)
+        if value is None:
+            continue
+        lines.append(_format_frontmatter_line(key, value))
+        seen.add(key)
+    for key, value in post.metadata.items():
+        if key in seen or value is None:
+            continue
+        lines.append(_format_frontmatter_line(key, value))
+    lines.append("---")
+    body = post.content.lstrip("\n")
+    return "\n".join(lines) + "\n\n" + body
+
+
+def _ensure_order(post: object, key: str) -> None:
+    if hasattr(post, "order"):
+        order = getattr(post, "order")
+        if isinstance(order, list) and key not in order:
+            order.append(key)
+
+
+def normalize_tag(tag: str) -> str:
+    tag = tag.strip()
+    if not tag:
+        return ""
+    tag = tag.replace("　", " ")
+    tag = re.sub(r"[\u3000\u200b]+", " ", tag)
+    tag = re.sub(r"[，,。；;：:！!？?（）()\[\]【】<>《》“”\"'·•…、/\\|]+", " ", tag)
+    tag = re.sub(r"\s+", " ", tag).strip()
+    ascii_candidate = unidecode(tag)
+    if ascii_candidate and re.fullmatch(r"[A-Za-z0-9\- ]+", ascii_candidate):
+        tag = ascii_candidate
+    if not tag:
+        return ""
+    lower_tag = tag.lower()
+    if lower_tag in SYN_MAP:
+        tag = SYN_MAP[lower_tag]
+    else:
+        tag = SYN_MAP.get(tag, tag)
+    if re.fullmatch(r"[A-Za-z0-9\- ]+", tag):
+        upper = tag.upper()
+        if len(upper.replace(" ", "")) <= 6:
+            tag = upper
+        else:
+            tag = upper.title()
+    return tag
+
+
+def cut_chinese(text: str) -> Iterable[str]:
+    if jieba is not None:
+        yield from jieba.cut(text, cut_all=False)
+    else:
+        for match in re.finditer(r"[\u4e00-\u9fff]{2,}", text):
+            yield match.group(0)
+
+
+def extract_keyword_candidates(text: str, top_k: int = 15) -> Iterable[Tuple[str, float]]:
+    if jieba_analyse is not None:
+        yield from jieba_analyse.extract_tags(text, topK=top_k, withWeight=True)
+        return
+    freq: Counter[str] = Counter()
+    for token in cut_chinese(text):
+        if len(token) < 2:
+            continue
+        freq[token] += 1
+    for match in re.finditer(r"[A-Za-z]{2,}", text):
+        freq[match.group(0).lower()] += 1
+    total = sum(freq.values()) or 1
+    for word, count in freq.most_common(top_k):
+        yield word, count / total
+
+
+def is_valid_tag(tag: str) -> bool:
+    if not tag:
+        return False
+    if tag in STOP_TAGS:
+        return False
+    if len(tag) > 18:
+        return False
+    has_cn = bool(CHINESE_RE.search(tag))
+    has_en = bool(ASCII_RE.search(tag))
+    if has_cn and has_en:
+        ascii_letters = "".join(ch for ch in tag if ch.isalpha())
+        if ascii_letters and not ascii_letters.isupper():
+            return False
+    if not has_cn and has_en:
+        condensed = tag.replace("-", "").replace(" ", "")
+        if condensed in ALLOWED_ASCII_TAGS:
+            return True
+        return False
+    return True
+
+
+def tokenize_for_similarity(text: str) -> Counter:
+    tokens: List[str] = []
+    # 中文分词
+    for word in cut_chinese(text):
+        word = word.strip()
+        if len(word) < 2:
+            continue
+        if re.fullmatch(r"[\d]+", word):
+            continue
+        normalized = normalize_tag(word)
+        if not normalized or len(normalized) == 1:
+            continue
+        tokens.append(normalized)
+    # 英文词干
+    for match in re.finditer(r"[A-Za-z]+", text):
+        w = match.group(0).lower()
+        stem = ps.stem(w)
+        if len(stem) < 2:
+            continue
+        tokens.append(stem)
+    counter = Counter(tokens)
+    return counter
+
+
+def cosine_similarity(counter_a: Counter, counter_b: Counter) -> float:
+    if not counter_a or not counter_b:
+        return 0.0
+    intersection = set(counter_a) & set(counter_b)
+    numerator = sum(counter_a[t] * counter_b[t] for t in intersection)
+    if numerator == 0:
+        return 0.0
+    norm_a = math.sqrt(sum(v * v for v in counter_a.values()))
+    norm_b = math.sqrt(sum(v * v for v in counter_b.values()))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return numerator / (norm_a * norm_b)
+
+
+def extract_synonym_line(line: str) -> Iterable[str]:
+    line = line.split("：", 1)[-1]
+    for sep in ["，", "、", ",", "/", "|", "或", ";", "；"]:
+        line = line.replace(sep, " ")
+    for token in line.split():
+        cleaned = normalize_tag(token)
+        if cleaned:
+            yield cleaned
+
+
+def collect_candidates(post: frontmatter.Post) -> Dict[str, float]:
+    candidates: Dict[str, float] = defaultdict(float)
+
+    def add_candidate(raw: str, weight: float = 1.0) -> None:
+        raw = (raw or "").strip()
+        if not raw:
+            return
+        if "#" in raw:
+            raw = raw.replace("#", "").strip()
+            if not raw:
+                return
+        if CHINESE_RE.search(raw) and ASCII_RE.search(raw) and re.search(r"\s", raw):
+            for part in re.split(r"[\s/、，,]+", raw):
+                if part and part != raw:
+                    add_candidate(part, weight * 0.6)
+            return
+        tag = normalize_tag(raw)
+        if not is_valid_tag(tag):
+            return
+        candidates[tag] += weight
+
+    tags_meta = post.metadata.get("tags", [])
+    if isinstance(tags_meta, str):
+        tags_meta = [tags_meta]
+    for tag in tags_meta or []:
+        add_candidate(tag, 2.5)
+
+    title = str(post.metadata.get("title", ""))
+    if title:
+        if len(title) <= 12:
+            add_candidate(title, 1.5)
+        m = re.match(r"([^（(]+)", title)
+        if m:
+            add_candidate(m.group(1), 2.0)
+        inner = re.findall(r"[（(]([^）)]+)[）)]", title)
+        for part in inner:
+            for token in re.split(r"[，、/,\s]+", part):
+                add_candidate(token, 1.8)
+
+    content = post.content
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.search(r"同义词|别称|亦称", stripped):
+            for tag in extract_synonym_line(stripped):
+                add_candidate(tag, 2.2)
+        if stripped.startswith("## "):
+            heading = stripped[3:]
+            add_candidate(heading, 1.0)
+        if stripped.startswith("- **") and "：" in stripped:
+            key = stripped.split("：", 1)[0]
+            key = re.sub(r"[-*\s]+", "", key)
+            key = key.strip("*")
+            add_candidate(key, 1.2)
+
+    summary_segment = "\n".join(lines[:20])
+    for word, weight in extract_keyword_candidates(summary_segment, top_k=15):
+        add_candidate(word, weight)
+
+    for tag, priority in PRIMARY_TAG_PRIORITY.items():
+        if tag in candidates:
+            candidates[tag] += priority
+
+    return candidates
+
+
+def pick_tags(post: frontmatter.Post) -> List[str]:
+    candidates = collect_candidates(post)
+    if not candidates:
+        return []
+    sorted_tags = sorted(
+        candidates.items(), key=lambda item: (item[1], item[0]), reverse=True
+    )
+    tags: List[str] = []
+    for tag, _score in sorted_tags:
+        if tag in tags:
+            continue
+        tags.append(tag)
+        if len(tags) >= MAX_TAGS:
+            break
+    if len(tags) < MIN_TAGS:
+        for tag in PRIMARY_TAG_PRIORITY:
+            if tag not in tags:
+                tags.append(tag)
+            if len(tags) >= MIN_TAGS:
+                break
+    return tags[:MAX_TAGS]
+
+
+def compute_related(
+    all_posts: Dict[Path, PostRecord],
+    cur_path: Path,
+    cur_tags: Sequence[str],
+) -> List[Tuple[Path, float]]:
+    cur_record = all_posts[cur_path]
+    cur_tag_set = set(cur_tags)
+    results: List[Tuple[Path, float]] = []
+
+    for other_path, record in all_posts.items():
+        if other_path == cur_path:
+            continue
+        other_tags = set(record.tags)
+        intersection = len(cur_tag_set & other_tags)
+        union = len(cur_tag_set | other_tags) or 1
+        jaccard = intersection / union
+        cos = cosine_similarity(cur_record.tokens, record.tokens)
+        score = 0.55 * jaccard + 0.30 * cos
+        if cur_path.parent == other_path.parent:
+            score += 0.15
+        if score <= 0:
+            continue
+        results.append((other_path, score))
+
+    results.sort(key=lambda item: item[1], reverse=True)
+    if len(results) < 2:
+        # 放宽条件，保留得分最高的若干条
+        all_sorted = sorted(
+            ((p, 0.01) for p in all_posts if p != cur_path),
+            key=lambda x: str(x[0]),
+        )
+        for item in all_sorted:
+            if item[0] == cur_path:
+                continue
+            results.append(item)
+            if len(results) >= 8:
+                break
+    return results[:8]
+
+
+def render_related_block(rel_list: List[Tuple[Path, float]], lookup: Dict[Path, PostRecord]) -> str:
+    lines = ["## 相关条目", ""]
+    for rel_path, _score in rel_list:
+        record = lookup[rel_path]
+        title = record.title or rel_path.stem
+        lines.append(f"- [{title}](/{rel_path.as_posix()})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def upsert_related_block(markdown_text: str, block: str) -> str:
+    if RELATED_BLOCK_RE.search(markdown_text):
+        return RELATED_BLOCK_RE.sub(block, markdown_text, count=1)
+    match = REF_SECTION_RE.search(markdown_text)
+    if match:
+        insert_pos = match.start()
+        before = markdown_text[:insert_pos].rstrip()
+        after = markdown_text[insert_pos:]
+        return before + "\n\n" + block + "\n\n" + after.lstrip()
+    return markdown_text.rstrip() + "\n\n" + block + "\n"
+
+
+def load_markdown(path: Path):
+    if frontmatter is not None:
+        return frontmatter.load(path)
+    return _simple_load(path)
+
+
+def dump_post(post: object) -> str:
+    if frontmatter is not None:
+        return frontmatter.dumps(post)
+    if isinstance(post, SimplePost):
+        return _simple_dump(post)
+    raise TypeError("Unsupported post type for dumping")
+
+
+def select_files(args: argparse.Namespace) -> Tuple[List[Path], List[Path]]:
+    all_files = sorted(ENTRIES_DIR.rglob("*.md"))
+    if args.only:
+        targets = [ROOT / Path(p) for p in args.only]
+    else:
+        targets = list(all_files)
+        if args.since:
+            git_cmd = [
+                "git",
+                "diff",
+                "--name-only",
+                f"{args.since}..HEAD",
+                "--",
+                "entries",
+            ]
+            result = subprocess.run(
+                git_cmd, cwd=ROOT, capture_output=True, text=True, check=False
+            )
+            if result.returncode == 0:
+                candidates = {
+                    ROOT / Path(line.strip())
+                    for line in result.stdout.splitlines()
+                    if line.strip()
+                }
+                if candidates:
+                    targets = [p for p in targets if p in candidates]
+    if args.limit:
+        targets = targets[: args.limit]
+    return all_files, targets
+
+
+def process(args: argparse.Namespace) -> None:
+    all_files, target_files = select_files(args)
+    if not target_files:
+        print("未找到需要处理的词条。")
+        return
+
+    records: Dict[Path, PostRecord] = {}
+
+    for path in all_files:
+        post = load_markdown(path)
+        tags = pick_tags(post)
+        title = str(post.metadata.get("title", path.stem))
+        tokens = tokenize_for_similarity(title + "\n" + post.content)
+        rel_path = path.relative_to(ROOT)
+        record = PostRecord(path=rel_path, title=title, tags=tags, tokens=tokens)
+        records[rel_path] = record
+
+    for path in target_files:
+        rel_path = path.relative_to(ROOT)
+        path = ROOT / rel_path
+        post = load_markdown(path)
+        tags = records[rel_path].tags
+        post.metadata["tags"] = tags
+        _ensure_order(post, "tags")
+
+        related = compute_related(records, rel_path, tags)
+        block = render_related_block(related, records)
+        updated_content = upsert_related_block(post.content, block)
+        post.content = updated_content
+
+        if args.dry_run:
+            print(
+                json.dumps(
+                    {
+                        "path": rel_path.as_posix(),
+                        "tags": tags,
+                        "related": [p.as_posix() for p, _ in related],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(dump_post(post))
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="批量重建词条标签与相关条目")
+    parser.add_argument("--dry-run", action="store_true", help="仅打印结果，不写回文件")
+    parser.add_argument("--limit", type=int, default=0, help="限制处理的文件数量")
+    parser.add_argument("--only", nargs="*", help="仅处理指定词条路径（entries/...）")
+    parser.add_argument(
+        "--since",
+        help="仅处理自指定 Git 基准以来有变更的词条，可传入 commit、tag 或日期字符串",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    process(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/retag_and_related.py` to normalize entry tags and rebuild "相关条目" lists; the tool falls back to a lightweight frontmatter parser when PyYAML/frontmatter are unavailable, tokenizes content (jieba or regex) and scores recommendations via weighted Jaccard, cosine similarity and directory proximity.
- document the new workflow in `docs/tools/README.md` and declare optional helpers (`pyyaml`, `python-frontmatter`, `jieba`, `nltk`, `unidecode`) in `requirements.txt` so contributors can mirror the automation locally.
- run the tool across every entry to refresh Frontmatter `tags` plus "相关条目" blocks, then regenerate `tags.md` so the global index reflects the new taxonomy.

## Testing
- python tools/retag_and_related.py --dry-run --limit 3
- python tools/retag_and_related.py
- python generate_tags_index.py
- pip install -r requirements.txt *(fails: proxy 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e0487e58f48333bd4469a103a0e8ae