### PR TITLE
fix: 统一 PDF 导出目录按标签生成

### DIFF
--- a/docs/pdf_export/README_pdf_output.md
+++ b/docs/pdf_export/README_pdf_output.md
@@ -53,6 +53,6 @@ python tools/pdf_export/export_to_pdf.py --pdf-engine xelatex
 - `--cover-title`、`--cover-subtitle`、`--cover-date` 可覆盖封面的默认文字。
 - 封面标题下方默认会展示可点击的“在线版本”链接，指向 <https://plurality-wiki.pages.dev/#/>，便于读者快速跳转至网页版内容。
 - `--cover-footer` 用于自定义封面底部的“plurality_wiki 项目”字样（默认以更大字号斜体排版），传入空字符串即可移除该行。
-- 目录页会根据 README 的分组与词条自动生成，默认不再展示各词条内部的小节标题。
+- 目录页会根据标签分组与词条自动生成，默认不再展示各词条内部的小节标题。
 
 如需进一步自定义输出文件名或其他设置，可执行 `python tools/pdf_export/export_to_pdf.py --help` 查看全部参数。

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -51,8 +51,7 @@ markdownlint "**/*.md" --ignore "node_modules" --ignore "tools/pdf_export/vendor
 
 ### PDF 导出目录生成逻辑
 
-- `tools/pdf_export/` 在导出 PDF 时会优先读取仓库根目录的 `index.md`，直接将其作为目录页内容；
-- 若 `index.md` 缺失或为空，则回退到按标签结构生成的默认目录；
+- `tools/pdf_export/` 在导出 PDF 时会按照词条标签结构生成目录页，与站点的标签索引保持一致；
 - 目录中的词条链接会自动重写为 PDF 内部锚点，确保离线文档中的跳转行为与线上一致。
 
 ## 相关文档

--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -14,11 +14,11 @@ cd tools/pdf_export && python -m pdf_export
 
 脚本会自动：
 
-1. 优先读取 `index.md` 中的目录结构，确保 PDF 的目录页与索引保持一致；
-2. 若索引缺失或被忽略，脚本会回退至 `README.md`，如两者均不可用则按 `entries/` 目录实际文件构建后备目录结构；
-3. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
-4. 在合并内容前，会优先插入项目根目录下的 `Preface.md`（若存在且未被忽略），以确保 PDF 以《前言》开篇；
-5. 收集 README 或后备目录中列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；在合并过程中会自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
+1. 解析 `entries/` 中所有词条的 Frontmatter，并按 `tags` 字段对词条分组；
+2. 对标签名称进行排序，每个标签章节内的词条按标题排序；
+3. 如果项目根目录存在 `Preface.md` 且未被忽略，则在所有标签章节之前插入《前言》；
+4. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
+5. 为每个章节中的词条单独开启新页面，并自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
 6. 自动识别 Markdown 中以 `entries/*.md` 形式书写的词条链接，并在合并时重写为指向 PDF 内部锚点的链接，确保离线文档中的交叉跳转仍可点击；
 7. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
 8. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
@@ -55,6 +55,6 @@ python tools/pdf_export/export_to_pdf.py --pdf-engine xelatex
 - `--cover-title`、`--cover-subtitle`、`--cover-date` 可覆盖封面的默认文字。
 - 封面标题下方默认会展示可点击的“在线版本”链接，指向 <https://plurality-wiki.pages.dev/#/>，便于读者快速跳转至网页版内容。
 - `--cover-footer` 用于自定义封面底部的“plurality_wiki 项目”字样（默认以更大字号斜体排版），传入空字符串即可移除该行。
-- 目录页会根据 README 的分组与词条自动生成，默认不再展示各词条内部的小节标题。
+- 目录页会根据标签分组与词条自动生成，默认不再展示各词条内部的小节标题。
 
 如需进一步自定义输出文件名或其他设置，可执行 `python tools/pdf_export/export_to_pdf.py --help` 查看全部参数。

--- a/tools/pdf_export/pdf_export/markdown.py
+++ b/tools/pdf_export/pdf_export/markdown.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import re
-import sys
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -243,48 +242,10 @@ def build_cover_page(
     return "\n".join(lines)
 
 
-def _build_directory_from_index(anchor_lookup: Mapping[Path, str]) -> str | None:
-    """尝试以仓库根目录的 ``index.md`` 作为目录页内容。"""
-
-    index_path = PROJECT_ROOT / "index.md"
-    if not index_path.exists():
-        return None
-
-    try:
-        raw_content = index_path.read_text(encoding="utf-8")
-    except OSError as error:  # pragma: no cover - 仅在 I/O 出错时触发
-        print(f"警告: 无法读取 {index_path}: {error}", file=sys.stderr)
-        return None
-
-    stripped = raw_content.strip()
-    if not stripped:
-        return None
-
-    lines = stripped.splitlines()
-    for index, line in enumerate(lines):
-        if line.startswith("# "):
-            lines[index] = "# 目录"
-            break
-    else:
-        lines.insert(0, "# 目录")
-        lines.insert(1, "")
-
-    directory_markdown = "\n".join(lines)
-    rewritten = rewrite_entry_links(directory_markdown, anchor_lookup).strip()
-    if not rewritten:
-        return None
-
-    return f"{rewritten}\n\n\\newpage\n"
-
-
 def build_directory_page(
     structure: CategoryStructure, anchor_lookup: Mapping[Path, str]
 ) -> str:
-    """根据 ``index.md`` 或标签结构生成目录页内容。"""
-
-    index_based = _build_directory_from_index(anchor_lookup)
-    if index_based is not None:
-        return index_based
+    """根据标签分组生成 PDF 使用的目录页内容。"""
 
     lines: list[str] = ["# 目录", ""]
 


### PR DESCRIPTION
## 摘要
- 移除 PDF 导出对 index.md 的依赖，目录页始终按照标签结构生成
- 更新工具总览与导出指南，说明目录构建逻辑已与标签索引保持一致

## 测试
- `python -m compileall tools/pdf_export/export_to_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68e04b81b90c8333a30be5ee65cc7dac