### PR TITLE
补充 Windows 本地维护批处理脚本

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -4,22 +4,39 @@
 
 ## 工具概览
 
-根目录下的 `tools/` 目录集中存放了协助批量处理、检查与发布的脚本，可与 CI 流程搭配使用；同时 `scripts/` 目录也包含部分自动化校验脚本：
-
-| 脚本/模块                            | 功能摘要                                                                               | 常用用法                                                                                                   |
-| -------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `tools/fix_md.py`                | 批量修复 Markdown 常见 Lint 问题，涵盖行尾空格、标题前后空行、围栏语言补全等                                     | `python tools/fix_md.py` 或 `python tools/fix_md.py --dry-run`                                          |
-| `tools/check_links.py`           | 扫描 Markdown 文档中疑似内部链接的写法，禁止 `./`、`../` 等相对路径并提示改为 `entries/*.md`               | `python tools/check_links.py --root .`，必要时使用 `--whitelist` 允许额外根目录文档                                   |
-| `tools/docs_preview.py`          | 本地预览辅助：优先尝试 `docsify-cli`，失败时自动回退到 `python -m http.server`                         | `python tools/docs_preview.py --port 4173`（可通过 `--wait` 调整 docsify 启动检测时间）                             |
-| `tools/gen_changelog_by_tags.py` | 按 Git 标签时间顺序生成 `changelog.md`，并按 Conventional Commits 类型分组                         | `python tools/gen_changelog_by_tags.py --output changelog.md`，可搭配 `--latest-only` 或 `--latest-to-head` |
-| `tools/pdf_export/`              | Pandoc 驱动的整站 PDF 导出工具，支持封面、目录、忽略列表与中文字体配置                                          | `python tools/pdf_export/export_to_pdf.py` 或 `python -m pdf_export`                                    |
-| `tools/gen-validation-report.py` | 读取《CONTRIBUTING.md》与《docs/TEMPLATE_ENTRY.md》，校验词条结构并生成 `docs/VALIDATION_REPORT.md` | `python tools/gen-validation-report.py`                                                                |
-| `tools/retag_and_related.py`     | 批量重建词条 Frontmatter 标签并生成“相关条目”区块，支持干跑、范围过滤等参数               | `python tools/retag_and_related.py`、`python tools/retag_and_related.py --dry-run --limit 5`             |
-| `generate_tags_index.py`         | 扫描 `entries/` Frontmatter，生成 `tags.md` 标签索引                                             | `python generate_tags_index.py`                                                                       |
+| 脚本/模块 | 功能摘要 | 常用用法 |
+| --- | --- | --- |
+| `tools/fix_md.py` | 批量修复 Markdown 常见 Lint 问题，涵盖行尾空格、标题前后空行、围栏语言补全等 | `python tools/fix_md.py` 或 `python tools/fix_md.py --dry-run` |
+| `tools/check_links.py` | 扫描 Markdown 文档中疑似内部链接写法，禁止 `./`、`../` 等相对路径 | `python tools/check_links.py --root .`，必要时配合 `--whitelist` |
+| `tools/docs_preview.py` | 本地预览辅助：优先尝试 `docsify-cli`，失败时回退 `python -m http.server` | `python tools/docs_preview.py --port 4173`（可用 `--wait` 调整检测时间） |
+| `tools/gen_changelog_by_tags.py` | 按 Git 标签时间顺序生成 `changelog.md` 并按提交类型分组 | `python tools/gen_changelog_by_tags.py --output changelog.md`，可加 `--latest-only`/`--latest-to-head` |
+| `tools/pdf_export/` | Pandoc 驱动的整站 PDF 导出工具，支持封面、忽略列表与中文字体 | `python tools/pdf_export/export_to_pdf.py` 或 `python -m pdf_export` |
+| `tools/gen-validation-report.py` | 校验词条结构并生成 `docs/VALIDATION_REPORT.md` | `python tools/gen-validation-report.py` |
+| `tools/retag_and_related.py` | 批量重建 Frontmatter 标签并生成“相关词条”区块 | `python tools/retag_and_related.py` 或 `python tools/retag_and_related.py --dry-run --limit 5` |
+| `tools/run_local_updates.sh` / `tools/run_local_updates.bat` | 串联常用维护脚本，一键完成日常更新任务 | `bash tools/run_local_updates.sh` 或 `tools\run_local_updates.bat`（均支持 `--skip-*` 选项） |
+| `generate_tags_index.py` | 扫描 Frontmatter 标签并生成 `tags.md` 索引 | `python generate_tags_index.py` |
 
 如需新增脚本，请保持功能说明与示例用法同步更新本章节，方便贡献者快速定位维护工具。
 
 ## 使用建议
+
+### 🏃 一键执行日常维护
+
+```bash
+# macOS / Linux 默认执行全部步骤
+bash tools/run_local_updates.sh
+
+# macOS / Linux 仅跳过 PDF 导出与 markdownlint
+bash tools/run_local_updates.sh --skip-pdf --skip-markdownlint
+
+# Windows 等效执行方式
+tools\run_local_updates.bat
+
+# Windows 同样可叠加跳过参数
+tools\run_local_updates.bat --skip-pdf --skip-markdownlint
+```
+
+> 两个脚本都会自动切换到仓库根目录，并依次调用 changelog 生成、标签重建、最后更新时间索引、PDF 导出、标签索引、Markdown 修复与 lint。
 
 ### 🧰 一键修复 Markdown
 

--- a/tools/run_local_updates.bat
+++ b/tools/run_local_updates.bat
@@ -1,0 +1,124 @@
+@echo off
+REM Windows 环境下一键执行常用维护脚本的批处理入口。
+setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+
+REM 切换到仓库根目录，确保相对路径一致。
+pushd "%~dp0.."
+
+set "SKIP_CHANGELOG=0"
+set "SKIP_RETAG=0"
+set "SKIP_LAST_UPDATED=0"
+set "SKIP_PDF=0"
+set "SKIP_TAG_INDEX=0"
+set "SKIP_FIX_MD=0"
+set "SKIP_MARKDOWNLINT=0"
+
+:parse_args
+if "%~1"=="" goto after_parse
+if "%~1"=="--skip-changelog" (
+  set "SKIP_CHANGELOG=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-retag" (
+  set "SKIP_RETAG=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-last-updated" (
+  set "SKIP_LAST_UPDATED=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-pdf" (
+  set "SKIP_PDF=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-tag-index" (
+  set "SKIP_TAG_INDEX=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-fix-md" (
+  set "SKIP_FIX_MD=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--skip-markdownlint" (
+  set "SKIP_MARKDOWNLINT=1"
+  shift
+  goto parse_args
+)
+if "%~1"=="--help" goto show_help
+if "%~1"=="-h" goto show_help
+
+echo 未识别的参数: %~1 1>&2
+popd
+exit /b 1
+
+:show_help
+echo 用法：tools\run_local_updates.bat [选项]
+echo.
+echo 默认执行以下步骤：
+echo   1. python tools\gen_changelog_by_tags.py --latest-to-head
+echo   2. python tools\retag_and_related.py
+echo   3. node scripts\gen-last-updated.mjs
+echo   4. python tools\pdf_export\export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei"
+echo   5. python tools\generate_tags_index.py
+echo   6. python tools\fix_md.py
+echo   7. markdownlint "**\*.md" --ignore "node_modules" --ignore "tools\pdf_export\vendor"
+echo.
+echo 可选参数：
+echo   --skip-changelog      跳过变更日志生成
+echo   --skip-retag          跳过标签与相关词条重建
+echo   --skip-last-updated   跳过最后更新时间索引生成
+echo   --skip-pdf            跳过 PDF 导出
+echo   --skip-tag-index      跳过标签索引生成
+echo   --skip-fix-md         跳过 Markdown 自动修复
+echo   --skip-markdownlint   跳过 markdownlint 校验
+echo   -h, --help            显示本帮助信息
+popd
+exit /b 0
+
+:after_parse
+
+call :maybe_run !SKIP_CHANGELOG! "生成变更日志" python tools\gen_changelog_by_tags.py --latest-to-head
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_RETAG! "刷新 Frontmatter 标签与相关词条" python tools\retag_and_related.py
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_LAST_UPDATED! "生成最后更新时间索引" node scripts\gen-last-updated.mjs
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_PDF! "导出 PDF" python tools\pdf_export\export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei"
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_TAG_INDEX! "生成标签索引" python tools\generate_tags_index.py
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_FIX_MD! "自动修复 Markdown" python tools\fix_md.py
+if errorlevel 1 goto script_fail
+call :maybe_run !SKIP_MARKDOWNLINT! "运行 markdownlint" markdownlint "**\*.md" --ignore "node_modules" --ignore "tools\pdf_export\vendor"
+if errorlevel 1 goto script_fail
+
+echo.
+echo 全部任务执行完毕。
+
+popd
+exit /b 0
+
+:maybe_run
+set "SKIP_FLAG=%~1"
+set "STEP_DESC=%~2"
+shift
+shift
+if "%SKIP_FLAG%"=="1" (
+  echo 已跳过：%STEP_DESC%
+  exit /b 0
+)
+
+echo.
+echo ^>^>^> %STEP_DESC%
+%*
+exit /b %errorlevel%
+
+:script_fail
+popd
+exit /b %errorlevel%

--- a/tools/run_local_updates.sh
+++ b/tools/run_local_updates.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# 用于在本地一次性执行常用维护脚本，统一入口便于日常更新。
+set -euo pipefail
+
+# 切换到仓库根目录，避免相对路径引发执行失败。
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# 默认执行全部步骤，可通过参数跳过特定命令。
+SKIP_CHANGELOG=false
+SKIP_RETAG=false
+SKIP_LAST_UPDATED=false
+SKIP_PDF=false
+SKIP_TAG_INDEX=false
+SKIP_FIX_MD=false
+SKIP_MARKDOWNLINT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-changelog)
+      SKIP_CHANGELOG=true
+      ;;
+    --skip-retag)
+      SKIP_RETAG=true
+      ;;
+    --skip-last-updated)
+      SKIP_LAST_UPDATED=true
+      ;;
+    --skip-pdf)
+      SKIP_PDF=true
+      ;;
+    --skip-tag-index)
+      SKIP_TAG_INDEX=true
+      ;;
+    --skip-fix-md)
+      SKIP_FIX_MD=true
+      ;;
+    --skip-markdownlint)
+      SKIP_MARKDOWNLINT=true
+      ;;
+    --help|-h)
+      cat <<'USAGE'
+用法：tools/run_local_updates.sh [选项]
+
+默认执行以下步骤：
+  1. python tools/gen_changelog_by_tags.py --latest-to-head
+  2. python tools/retag_and_related.py
+  3. node scripts/gen-last-updated.mjs
+  4. python tools/pdf_export/export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei"
+  5. python tools/generate_tags_index.py
+  6. python tools/fix_md.py
+  7. markdownlint "**/*.md" --ignore "node_modules" --ignore "tools/pdf_export/vendor"
+
+可选参数：
+  --skip-changelog      跳过变更日志生成
+  --skip-retag          跳过标签与关联词条重建
+  --skip-last-updated   跳过最后更新时间索引生成
+  --skip-pdf            跳过 PDF 导出
+  --skip-tag-index      跳过标签索引生成
+  --skip-fix-md         跳过 Markdown 自动修复
+  --skip-markdownlint   跳过 markdownlint 校验
+  -h, --help            显示本帮助信息
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "未识别的参数：$1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+run_step() {
+  local description="$1"
+  shift
+  echo "\n>>> ${description}" >&2
+  "$@"
+}
+
+if ! ${SKIP_CHANGELOG}; then
+  run_step "生成变更日志" python tools/gen_changelog_by_tags.py --latest-to-head
+else
+  echo "已跳过：变更日志生成" >&2
+fi
+
+if ! ${SKIP_RETAG}; then
+  run_step "刷新 Frontmatter 标签与相关词条" python tools/retag_and_related.py
+else
+  echo "已跳过：标签与相关词条重建" >&2
+fi
+
+if ! ${SKIP_LAST_UPDATED}; then
+  run_step "生成最后更新时间索引" node scripts/gen-last-updated.mjs
+else
+  echo "已跳过：最后更新时间索引" >&2
+fi
+
+if ! ${SKIP_PDF}; then
+  run_step "导出 PDF" python tools/pdf_export/export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei"
+else
+  echo "已跳过：PDF 导出" >&2
+fi
+
+if ! ${SKIP_TAG_INDEX}; then
+  run_step "生成标签索引" python tools/generate_tags_index.py
+else
+  echo "已跳过：标签索引生成" >&2
+fi
+
+if ! ${SKIP_FIX_MD}; then
+  run_step "自动修复 Markdown" python tools/fix_md.py
+else
+  echo "已跳过：Markdown 自动修复" >&2
+fi
+
+if ! ${SKIP_MARKDOWNLINT}; then
+  run_step "运行 markdownlint" markdownlint "**/*.md" --ignore "node_modules" --ignore "tools/pdf_export/vendor"
+else
+  echo "已跳过：markdownlint 校验" >&2
+fi
+
+echo "\n全部任务执行完毕。" >&2


### PR DESCRIPTION
## 摘要
- 新增 `tools/run_local_updates.bat`，在 Windows 环境提供与 Bash 脚本等效的一键维护入口并支持跳过各子任务。
- 更新 `docs/tools/README.md`，补充批处理脚本的使用说明及跨平台示例。

## 测试
- 未执行（批处理脚本需在 Windows 环境验证）。

------
https://chatgpt.com/codex/tasks/task_e_68e05c346bc08333a2964ab09f7214cf