### PR TITLE
修复文档质量检查缺失依赖安装

### DIFF
--- a/.github/workflows/docs_quality.yml
+++ b/.github/workflows/docs_quality.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: 安装 Python 依赖
+        run: pip install -r requirements.txt
       - name: 校验标签索引
         run: |
           python tools/generate_tags_index.py


### PR DESCRIPTION
## 摘要
- 在文档质量检查工作流中增加 Python 依赖安装步骤，确保标签索引脚本能正确导入 PyYAML

## 测试
- 未运行（工作流配置修改）

------
https://chatgpt.com/codex/tasks/task_e_68e0c634ae6c8333a871b45b0d9e37d1