### PR TITLE
fix: 补全《独立性》词条同义词元数据

### DIFF
--- a/assets/last-updated.json
+++ b/assets/last-updated.json
@@ -1,482 +1,482 @@
 {
   "entries/Adaptive.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Admin.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Alcohol-Induced-Dissociation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Alexithymia.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Alter.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Alterhuman.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Another-Me-DID-Depictions.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Anxiety.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Apparently-Normal-Part-Emotional-Part-Model.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Attention-Deficit-Hyperactivity-Disorder-ADHD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Autism-Spectrum-Disorder.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Autopilot.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Back-Being-Back.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Bias.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Bipolar-Disorders.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Blending.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Body-Ownership.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Borderline-Personality-Disorder-BPD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Bu-Ke-Raoshu-De-Ta-Multiplicity-Narrative.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/CPTSD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Caregiver.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Co-Consciousness.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Co-Fronting.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Consciousness-Modification.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Core.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/DID.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Delirium.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Depersonalization-Derealization-Disorder-DPDR.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Depersonalization.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Depressive-Disorders.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Derealization.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Disorientation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Dissociation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Dissociative-Amnesia-DA.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Dostoevsky-The-Double-Self-Division.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Emmengard-Classification.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Exomemory.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/External-Projection.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Family-Systems-Xianyu.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Fauxmain.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Fight-Club-1999-Identity-Metaphor.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Flashback.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Fragment.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Front-Fronting.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Functional-Dissociation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Fusion.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Gatekeeper.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Grounding.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Hatsune-Miku-Virtual-Idol-Tulpa-Boundary.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Head-Pressure.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Headspace-Inner-World.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Host.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Iatrogenic-System.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Imaginary-Companion.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Independence.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Integration.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Internal-Communication.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Internal-Self-Helper-ISH.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Intrusive-Thoughts.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Iteration.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Kafka-Metamorphosis-Identity-Dissolution.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Learned-Helplessness.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Little.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Lovecraft-Tulpa-Motifs.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Madoka-Magica-Kyubey-Otherness.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Main.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Mania.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Meditation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Memory-Holder.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Memory-Shielding.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Mixed-Systems-Xianyu.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Mr-Robot-DID-Narrative.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Narcissistic-Personality-Disorder-NPD.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Neurodiversity.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Nonexistent-You-And-Me-Tulpa-Lilith.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/OCD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/OSDD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Original.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/PTSD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Paranoia-Agent-Collective-Consciousness.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Partial-Dissociative-Identity-Disorder-PDID.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Pathological-Dissociation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Performer-Executive.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Permissions.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Persecutor.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Persona.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Plurality-Basics.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Plurality.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Polyfragmented.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Projection.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Protector.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Reconstruction.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Regression-In-Psychology.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Schizophrenia-SC.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Sense-Of-Presence.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Sensory-Regulation-Strategies.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Sequestration.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Servitor.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Single-Class-Systems-Xianyu.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Somatic-Symptom-Disorder-SSD.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Soul-Linked-Systems-Xianyu.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Soulbond.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Split-2016-DID-Representation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Spontaneous.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Stress-Response.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Structural-Dissociation-Theory.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Switch.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Sybil-1976-Cultural-Prototype.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/System-Roles.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/System.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Teen.md": {
     "updated": "2025-10-04T16:12:13+08:00",
     "commit": "37f83b3256f5405be4054d7807068518bb20b961"
   },
   "entries/Three-Faces-Of-Eve-1957-Dissociation.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Touhou-Tulpa-Fandom.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Trauma.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Trigger.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Tulpa.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Tulpish.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/United-States-Of-Tara-System-Daily-Life.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Visualization-Imagination.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   },
   "entries/Xianyu-Theory-Niche-Classification.md": {
-    "updated": "2025-10-04T16:12:13+08:00",
-    "commit": "37f83b3256f5405be4054d7807068518bb20b961"
+    "updated": "2025-10-04T16:44:01+08:00",
+    "commit": "8c2612cf976a0422a431b3d1fb6226acfcabdcba"
   }
 }

--- a/entries/Independence.md
+++ b/entries/Independence.md
@@ -3,6 +3,9 @@ tags:
 - 多重意识体
 - 解离
 - 创伤
+synonyms:
+- 独立意识
+- Independence
 title: 独立性（Independence）
 updated: 2025-10-03
 ---


### PR DESCRIPTION
## 摘要
- 在《独立性（Independence）》词条 Frontmatter 中补全 `synonyms` 列表，保证搜索索引可使用该元数据。
- 重新生成 `assets/last-updated.json`，同步记录词条最新修改时间。

## 测试
- 未运行（文档元数据调整）。

------
https://chatgpt.com/codex/tasks/task_e_68e0de8ee4cc83338497373721ff6d43