### PR TITLE
修正 Docsify 搜索索引标题别名解析

### DIFF
--- a/assets/search-index.json
+++ b/assets/search-index.json
@@ -6,6 +6,8 @@
       "title": "适应型（Adaptive）",
       "aliases": [
         "Adaptive",
+        "创伤型",
+        "适应型",
         "适应型（Adaptive）"
       ],
       "tokens": [
@@ -13,6 +15,31 @@
           "normalized": "adaptive",
           "display": "Adaptive",
           "kind": "alias"
+        },
+        {
+          "normalized": "gua ying xing ",
+          "display": "适应型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "guayingxing",
+          "display": "适应型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "适应型",
+          "display": "适应型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "csx",
+          "display": "csx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "gyx",
+          "display": "gyx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "gyxa",
@@ -23,6 +50,21 @@
           "normalized": "guayingxingadaptive",
           "display": "guayingxingadaptive",
           "kind": "pinyin_full"
+        },
+        {
+          "normalized": "chuang shang xing ",
+          "display": "创伤型",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "chuangshangxing",
+          "display": "创伤型",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "创伤型",
+          "display": "创伤型",
+          "kind": "synonym"
         },
         {
           "normalized": "gua ying xing (adaptive)",
@@ -46,6 +88,9 @@
       "title": "管理者（Admin）",
       "aliases": [
         "Admin",
+        "admin",
+        "管理员",
+        "管理者",
         "管理者（Admin）"
       ],
       "tokens": [
@@ -53,6 +98,31 @@
           "normalized": "admin",
           "display": "Admin",
           "kind": "alias"
+        },
+        {
+          "normalized": "guan li zhe ",
+          "display": "管理者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "guanlizhe",
+          "display": "管理者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "管理者",
+          "display": "管理者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gly",
+          "display": "gly",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "glz",
+          "display": "glz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "glza",
@@ -63,6 +133,21 @@
           "normalized": "guanlizheadmin",
           "display": "guanlizheadmin",
           "kind": "pinyin_full"
+        },
+        {
+          "normalized": "guan li yuan ",
+          "display": "管理员",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "guanliyuan",
+          "display": "管理员",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "管理员",
+          "display": "管理员",
+          "kind": "synonym"
         },
         {
           "normalized": "guan li zhe (admin)",
@@ -86,6 +171,7 @@
       "title": "醉酒解离（Alcohol-Induced Dissociation）",
       "aliases": [
         "Alcohol-Induced Dissociation",
+        "醉酒解离",
         "醉酒解离（Alcohol-Induced Dissociation）"
       ],
       "tokens": [
@@ -98,6 +184,26 @@
           "normalized": "alcoholinduceddissociation",
           "display": "Alcohol-Induced Dissociation",
           "kind": "alias"
+        },
+        {
+          "normalized": "zui jiu jie chi ",
+          "display": "醉酒解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zuijiujiechi",
+          "display": "醉酒解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "醉酒解离",
+          "display": "醉酒解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zjjc",
+          "display": "zjjc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zjjcaid",
@@ -136,6 +242,11 @@
       "title": "述情障碍（Alexithymia）",
       "aliases": [
         "Alexithymia",
+        "alexithymia",
+        "情感表达不能",
+        "情感难言症",
+        "述情困难",
+        "述情障碍",
         "述情障碍（Alexithymia）"
       ],
       "tokens": [
@@ -143,6 +254,41 @@
           "normalized": "alexithymia",
           "display": "Alexithymia",
           "kind": "alias"
+        },
+        {
+          "normalized": "shu qing zhang ai ",
+          "display": "述情障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "shuqingzhangai",
+          "display": "述情障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "述情障碍",
+          "display": "述情障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qgbdbn",
+          "display": "qgbdbn",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qgnyz",
+          "display": "qgnyz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "sqkn",
+          "display": "sqkn",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "sqza",
+          "display": "sqza",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "sqzaa",
@@ -153,6 +299,51 @@
           "normalized": "shuqingzhangaialexithymia",
           "display": "shuqingzhangaialexithymia",
           "kind": "pinyin_full"
+        },
+        {
+          "normalized": "qing gan biao da bu neng ",
+          "display": "情感表达不能",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "qing gan nan yan zheng ",
+          "display": "情感难言症",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "qingganbiaodabuneng",
+          "display": "情感表达不能",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "qinggannanyanzheng",
+          "display": "情感难言症",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "shu qing kun nan ",
+          "display": "述情困难",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "shuqingkunnan",
+          "display": "述情困难",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "情感表达不能",
+          "display": "情感表达不能",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "情感难言症",
+          "display": "情感难言症",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "述情困难",
+          "display": "述情困难",
+          "kind": "synonym"
         },
         {
           "normalized": "shu qing zhang ai (alexithymia)",
@@ -176,6 +367,7 @@
       "title": "成员（Alter）",
       "aliases": [
         "Alter",
+        "成员",
         "成员（Alter）"
       ],
       "tokens": [
@@ -183,6 +375,26 @@
           "normalized": "alter",
           "display": "Alter",
           "kind": "alias"
+        },
+        {
+          "normalized": "cheng yuan ",
+          "display": "成员",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chengyuan",
+          "display": "成员",
+          "kind": "alias"
+        },
+        {
+          "normalized": "成员",
+          "display": "成员",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cy",
+          "display": "cy",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "cya",
@@ -216,6 +428,7 @@
       "title": "特殊认同（Alterhuman）",
       "aliases": [
         "Alterhuman",
+        "特殊认同",
         "特殊认同（Alterhuman）"
       ],
       "tokens": [
@@ -223,6 +436,26 @@
           "normalized": "alterhuman",
           "display": "Alterhuman",
           "kind": "alias"
+        },
+        {
+          "normalized": "te shu ren tong ",
+          "display": "特殊认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "teshurentong",
+          "display": "特殊认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "特殊认同",
+          "display": "特殊认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "tsrt",
+          "display": "tsrt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "tsrta",
@@ -256,9 +489,53 @@
       "title": "《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
       "aliases": [
         "Another Me DID Depictions",
-        "《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）"
+        "《Another Me》",
+        "《Another Me》/《双重人格》类作品的 DID 表现",
+        "《Another Me》/《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
+        "《双重人格》类作品的 DID 表现",
+        "《双重人格》类作品的 DID 表现（Another Me DID Depictions）"
       ],
       "tokens": [
+        {
+          "normalized": "<<another me>> ",
+          "display": "《Another Me》",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<another me>> /<<shuang zhong ren ge >> lei zuo pin de  did biao xian ",
+          "display": "《Another Me》/《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<anotherme>>",
+          "display": "《Another Me》",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<anotherme>><<shuangzhongrenge>>leizuopindedidbiaoxian",
+          "display": "《Another Me》/《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<shuang zhong ren ge >> lei zuo pin de  did biao xian ",
+          "display": "《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<shuang zhong ren ge >> lei zuo pin de  did biao xian (another me did depictions)",
+          "display": "《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<shuangzhongrenge>>leizuopindedidbiaoxian",
+          "display": "《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<shuangzhongrenge>>leizuopindedidbiaoxian(anothermediddepictions)",
+          "display": "《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
+          "kind": "alias"
+        },
         {
           "normalized": "another me did depictions",
           "display": "Another Me DID Depictions",
@@ -270,13 +547,83 @@
           "kind": "alias"
         },
         {
+          "normalized": "《another me》",
+          "display": "《Another Me》",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《another me》/《双重人格》类作品的 did 表现",
+          "display": "《Another Me》/《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《anotherme》",
+          "display": "《Another Me》",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《anotherme》《双重人格》类作品的did表现",
+          "display": "《Another Me》/《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《双重人格》类作品的 did 表现",
+          "display": "《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《双重人格》类作品的 did 表现（another me did depictions）",
+          "display": "《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《双重人格》类作品的did表现",
+          "display": "《双重人格》类作品的 DID 表现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《双重人格》类作品的did表现（anothermediddepictions）",
+          "display": "《双重人格》类作品的 DID 表现（Another Me DID Depictions）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "amszrglzpddbx",
+          "display": "amszrglzpddbx",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "amszrglzpddbxamdd",
           "display": "amszrglzpddbxamdd",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "szrglzpddbx",
+          "display": "szrglzpddbx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "szrglzpddbxamdd",
+          "display": "szrglzpddbxamdd",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "anothermeshuangzhongrengeleizuopindedidbiaoxian",
+          "display": "anothermeshuangzhongrengeleizuopindedidbiaoxian",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "anothermeshuangzhongrengeleizuopindedidbiaoxiananothermediddepictions",
           "display": "anothermeshuangzhongrengeleizuopindedidbiaoxiananothermediddepictions",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "shuangzhongrengeleizuopindedidbiaoxian",
+          "display": "shuangzhongrengeleizuopindedidbiaoxian",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "shuangzhongrengeleizuopindedidbiaoxiananothermediddepictions",
+          "display": "shuangzhongrengeleizuopindedidbiaoxiananothermediddepictions",
           "kind": "pinyin_full"
         },
         {
@@ -306,6 +653,7 @@
       "title": "焦虑（Anxiety）",
       "aliases": [
         "Anxiety",
+        "焦虑",
         "焦虑（Anxiety）"
       ],
       "tokens": [
@@ -313,6 +661,26 @@
           "normalized": "anxiety",
           "display": "Anxiety",
           "kind": "alias"
+        },
+        {
+          "normalized": "jiao lu ",
+          "display": "焦虑",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiaolu",
+          "display": "焦虑",
+          "kind": "alias"
+        },
+        {
+          "normalized": "焦虑",
+          "display": "焦虑",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jl",
+          "display": "jl",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jla",
@@ -345,10 +713,31 @@
       "path": "entries/Apparently-Normal-Part-Emotional-Part-Model.md",
       "title": "ANP-EP 模型（Apparently Normal Part–Emotional Part Model）",
       "aliases": [
+        "ANP-EP 模型",
         "ANP-EP 模型（Apparently Normal Part–Emotional Part Model）",
         "Apparently Normal Part–Emotional Part Model"
       ],
       "tokens": [
+        {
+          "normalized": "anp-ep mo xing ",
+          "display": "ANP-EP 模型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "anp-ep 模型",
+          "display": "ANP-EP 模型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "anpepmoxing",
+          "display": "ANP-EP 模型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "anpep模型",
+          "display": "ANP-EP 模型",
+          "kind": "alias"
+        },
         {
           "normalized": "apparently normal part-emotional part model",
           "display": "Apparently Normal Part–Emotional Part Model",
@@ -368,6 +757,11 @@
           "normalized": "apparentlynormalpart–emotionalpartmodel",
           "display": "Apparently Normal Part–Emotional Part Model",
           "kind": "alias"
+        },
+        {
+          "normalized": "aemx",
+          "display": "aemx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "aemxanpepm",
@@ -406,8 +800,13 @@
       "title": "注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）",
       "aliases": [
         "ADHD",
+        "ADHD）",
         "Attention-Deficit",
+        "Attention-Deficit/Hyperactivity Disorder，ADHD",
         "Hyperactivity Disorder",
+        "多动症",
+        "注意缺陷多动障碍",
+        "注意缺陷多动障碍（Attention-Deficit",
         "注意缺陷多动障碍（Attention-Deficit/Hyperactivity Disorder，ADHD）"
       ],
       "tokens": [
@@ -417,13 +816,43 @@
           "kind": "alias"
         },
         {
+          "normalized": "adhd)",
+          "display": "ADHD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "adhd）",
+          "display": "ADHD）",
+          "kind": "alias"
+        },
+        {
           "normalized": "attention-deficit",
           "display": "Attention-Deficit",
           "kind": "alias"
         },
         {
+          "normalized": "attention-deficit/hyperactivity disorder,adhd",
+          "display": "Attention-Deficit/Hyperactivity Disorder，ADHD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "attention-deficit/hyperactivity disorder，adhd",
+          "display": "Attention-Deficit/Hyperactivity Disorder，ADHD",
+          "kind": "alias"
+        },
+        {
           "normalized": "attentiondeficit",
           "display": "Attention-Deficit",
+          "kind": "alias"
+        },
+        {
+          "normalized": "attentiondeficithyperactivitydisorder,adhd",
+          "display": "Attention-Deficit/Hyperactivity Disorder，ADHD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "attentiondeficithyperactivitydisorder，adhd",
+          "display": "Attention-Deficit/Hyperactivity Disorder，ADHD",
           "kind": "alias"
         },
         {
@@ -437,14 +866,84 @@
           "kind": "alias"
         },
         {
+          "normalized": "zhu yi que xian duo dong zhang ai ",
+          "display": "注意缺陷多动障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhu yi que xian duo dong zhang ai (attention-deficit",
+          "display": "注意缺陷多动障碍（Attention-Deficit",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhuyiquexianduodongzhangai",
+          "display": "注意缺陷多动障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhuyiquexianduodongzhangai(attentiondeficit",
+          "display": "注意缺陷多动障碍（Attention-Deficit",
+          "kind": "alias"
+        },
+        {
+          "normalized": "注意缺陷多动障碍",
+          "display": "注意缺陷多动障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "注意缺陷多动障碍（attention-deficit",
+          "display": "注意缺陷多动障碍（Attention-Deficit",
+          "kind": "alias"
+        },
+        {
+          "normalized": "注意缺陷多动障碍（attentiondeficit",
+          "display": "注意缺陷多动障碍（Attention-Deficit",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ddz",
+          "display": "ddz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zyqxddza",
+          "display": "zyqxddza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zyqxddzaad",
+          "display": "zyqxddzaad",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "zyqxddzaadhda",
           "display": "zyqxddzaadhda",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "zhuyiquexianduodongzhangaiattentiondeficit",
+          "display": "zhuyiquexianduodongzhangaiattentiondeficit",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "zhuyiquexianduodongzhangaiattentiondeficithyperactivitydisorderadhd",
           "display": "zhuyiquexianduodongzhangaiattentiondeficithyperactivitydisorderadhd",
           "kind": "pinyin_full"
+        },
+        {
+          "normalized": "duo dong zheng ",
+          "display": "多动症",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "duodongzheng",
+          "display": "多动症",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "多动症",
+          "display": "多动症",
+          "kind": "synonym"
         },
         {
           "normalized": "zhu yi que xian duo dong zhang ai (attention-deficit/hyperactivity disorder,adhd)",
@@ -473,6 +972,7 @@
       "title": "孤独症谱系（Autism Spectrum Disorder）",
       "aliases": [
         "Autism Spectrum Disorder",
+        "孤独症谱系",
         "孤独症谱系（Autism Spectrum Disorder）"
       ],
       "tokens": [
@@ -485,6 +985,26 @@
           "normalized": "autismspectrumdisorder",
           "display": "Autism Spectrum Disorder",
           "kind": "alias"
+        },
+        {
+          "normalized": "gu du zheng pu xi ",
+          "display": "孤独症谱系",
+          "kind": "alias"
+        },
+        {
+          "normalized": "guduzhengpuxi",
+          "display": "孤独症谱系",
+          "kind": "alias"
+        },
+        {
+          "normalized": "孤独症谱系",
+          "display": "孤独症谱系",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gdzpx",
+          "display": "gdzpx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "gdzpxasd",
@@ -523,6 +1043,7 @@
       "title": "自动驾驶（Autopilot）",
       "aliases": [
         "Autopilot",
+        "自动驾驶",
         "自动驾驶（Autopilot）"
       ],
       "tokens": [
@@ -530,6 +1051,26 @@
           "normalized": "autopilot",
           "display": "Autopilot",
           "kind": "alias"
+        },
+        {
+          "normalized": "zi dong jia shi ",
+          "display": "自动驾驶",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zidongjiashi",
+          "display": "自动驾驶",
+          "kind": "alias"
+        },
+        {
+          "normalized": "自动驾驶",
+          "display": "自动驾驶",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zdjs",
+          "display": "zdjs",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zdjsa",
@@ -563,7 +1104,11 @@
       "title": "后台（Back / Being Back）",
       "aliases": [
         "Back",
+        "Back / Being Back",
         "Being Back",
+        "Being Back）",
+        "后台",
+        "后台（Back",
         "后台（Back / Being Back）"
       ],
       "tokens": [
@@ -573,8 +1118,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "back / being back",
+          "display": "Back / Being Back",
+          "kind": "alias"
+        },
+        {
+          "normalized": "backbeingback",
+          "display": "Back / Being Back",
+          "kind": "alias"
+        },
+        {
           "normalized": "being back",
           "display": "Being Back",
+          "kind": "alias"
+        },
+        {
+          "normalized": "being back)",
+          "display": "Being Back）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "being back）",
+          "display": "Being Back）",
           "kind": "alias"
         },
         {
@@ -583,9 +1148,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "beingback)",
+          "display": "Being Back）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "beingback）",
+          "display": "Being Back）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hou tai ",
+          "display": "后台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hou tai (back",
+          "display": "后台（Back",
+          "kind": "alias"
+        },
+        {
+          "normalized": "houtai",
+          "display": "后台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "houtai(back",
+          "display": "后台（Back",
+          "kind": "alias"
+        },
+        {
+          "normalized": "后台",
+          "display": "后台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "后台（back",
+          "display": "后台（Back",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ht",
+          "display": "ht",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "htb",
+          "display": "htb",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "htbbb",
           "display": "htbbb",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "houtaiback",
+          "display": "houtaiback",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "houtaibackbeingback",
@@ -619,7 +1239,11 @@
       "title": "偏重（Bias / Median）",
       "aliases": [
         "Bias",
+        "Bias / Median",
         "Median",
+        "Median）",
+        "偏重",
+        "偏重（Bias",
         "偏重（Bias / Median）"
       ],
       "tokens": [
@@ -629,14 +1253,79 @@
           "kind": "alias"
         },
         {
+          "normalized": "bias / median",
+          "display": "Bias / Median",
+          "kind": "alias"
+        },
+        {
+          "normalized": "biasmedian",
+          "display": "Bias / Median",
+          "kind": "alias"
+        },
+        {
           "normalized": "median",
           "display": "Median",
           "kind": "alias"
         },
         {
+          "normalized": "median)",
+          "display": "Median）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "median）",
+          "display": "Median）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pian zhong ",
+          "display": "偏重",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pian zhong (bias",
+          "display": "偏重（Bias",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pianzhong",
+          "display": "偏重",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pianzhong(bias",
+          "display": "偏重（Bias",
+          "kind": "alias"
+        },
+        {
+          "normalized": "偏重",
+          "display": "偏重",
+          "kind": "alias"
+        },
+        {
+          "normalized": "偏重（bias",
+          "display": "偏重（Bias",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pz",
+          "display": "pz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "pzb",
+          "display": "pzb",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "pzbm",
           "display": "pzbm",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "pianzhongbias",
+          "display": "pianzhongbias",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "pianzhongbiasmedian",
@@ -670,6 +1359,7 @@
       "title": "双相障碍（Bipolar Disorders）",
       "aliases": [
         "Bipolar Disorders",
+        "双相障碍",
         "双相障碍（Bipolar Disorders）"
       ],
       "tokens": [
@@ -682,6 +1372,26 @@
           "normalized": "bipolardisorders",
           "display": "Bipolar Disorders",
           "kind": "alias"
+        },
+        {
+          "normalized": "shuang xiang zhang ai ",
+          "display": "双相障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "shuangxiangzhangai",
+          "display": "双相障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "双相障碍",
+          "display": "双相障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sxza",
+          "display": "sxza",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "sxzabd",
@@ -720,6 +1430,7 @@
       "title": "混合（Blending）",
       "aliases": [
         "Blending",
+        "混合",
         "混合（Blending）"
       ],
       "tokens": [
@@ -727,6 +1438,26 @@
           "normalized": "blending",
           "display": "Blending",
           "kind": "alias"
+        },
+        {
+          "normalized": "hun he ",
+          "display": "混合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hunhe",
+          "display": "混合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "混合",
+          "display": "混合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hh",
+          "display": "hh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "hhb",
@@ -760,6 +1491,7 @@
       "title": "躯体认同（Body Ownership）",
       "aliases": [
         "Body Ownership",
+        "躯体认同",
         "躯体认同（Body Ownership）"
       ],
       "tokens": [
@@ -772,6 +1504,26 @@
           "normalized": "bodyownership",
           "display": "Body Ownership",
           "kind": "alias"
+        },
+        {
+          "normalized": "qu ti ren tong ",
+          "display": "躯体认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qutirentong",
+          "display": "躯体认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "躯体认同",
+          "display": "躯体认同",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qtrt",
+          "display": "qtrt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qtrtbo",
@@ -810,13 +1562,47 @@
       "title": "边缘性人格障碍（Borderline Personality Disorder，BPD）",
       "aliases": [
         "BPD",
+        "BPD）",
         "Borderline Personality Disorder",
+        "Borderline Personality Disorder，BPD",
+        "边缘性人格障碍",
+        "边缘性人格障碍（Borderline Personality Disorder",
         "边缘性人格障碍（Borderline Personality Disorder，BPD）"
       ],
       "tokens": [
         {
+          "normalized": "bian yuan xing ren ge zhang ai ",
+          "display": "边缘性人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bian yuan xing ren ge zhang ai (borderline personality disorder",
+          "display": "边缘性人格障碍（Borderline Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bianyuanxingrengezhangai",
+          "display": "边缘性人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bianyuanxingrengezhangai(borderlinepersonalitydisorder",
+          "display": "边缘性人格障碍（Borderline Personality Disorder",
+          "kind": "alias"
+        },
+        {
           "normalized": "borderline personality disorder",
           "display": "Borderline Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "borderline personality disorder,bpd",
+          "display": "Borderline Personality Disorder，BPD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "borderline personality disorder，bpd",
+          "display": "Borderline Personality Disorder，BPD",
           "kind": "alias"
         },
         {
@@ -825,14 +1611,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "borderlinepersonalitydisorder,bpd",
+          "display": "Borderline Personality Disorder，BPD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "borderlinepersonalitydisorder，bpd",
+          "display": "Borderline Personality Disorder，BPD",
+          "kind": "alias"
+        },
+        {
           "normalized": "bpd",
           "display": "BPD",
           "kind": "alias"
         },
         {
+          "normalized": "bpd)",
+          "display": "BPD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bpd）",
+          "display": "BPD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "边缘性人格障碍",
+          "display": "边缘性人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "边缘性人格障碍（borderline personality disorder",
+          "display": "边缘性人格障碍（Borderline Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "边缘性人格障碍（borderlinepersonalitydisorder",
+          "display": "边缘性人格障碍（Borderline Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "byxrgza",
+          "display": "byxrgza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "byxrgzabpd",
+          "display": "byxrgzabpd",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "byxrgzabpdb",
           "display": "byxrgzabpdb",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bianyuanxingrengezhangaiborderlinepersonalitydisorder",
+          "display": "bianyuanxingrengezhangaiborderlinepersonalitydisorder",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "bianyuanxingrengezhangaiborderlinepersonalitydisorderbpd",
@@ -866,9 +1702,20 @@
       "title": "《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）",
       "aliases": [
         "Bu Ke Rao Shu De Ta Multiplicity Narrative",
+        "《不可饶恕的她》对多重人格的叙事化呈现",
         "《不可饶恕的她》对多重人格的叙事化呈现（Bu Ke Rao Shu De Ta Multiplicity Narrative）"
       ],
       "tokens": [
+        {
+          "normalized": "<<bu ke rao shu de ta >> dui duo zhong ren ge de xu shi hua cheng xian ",
+          "display": "《不可饶恕的她》对多重人格的叙事化呈现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bukeraoshudeta>>duiduozhongrengedexushihuachengxian",
+          "display": "《不可饶恕的她》对多重人格的叙事化呈现",
+          "kind": "alias"
+        },
         {
           "normalized": "bu ke rao shu de ta multiplicity narrative",
           "display": "Bu Ke Rao Shu De Ta Multiplicity Narrative",
@@ -880,9 +1727,24 @@
           "kind": "alias"
         },
         {
+          "normalized": "《不可饶恕的她》对多重人格的叙事化呈现",
+          "display": "《不可饶恕的她》对多重人格的叙事化呈现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bkrsdtddzrgdxshcx",
+          "display": "bkrsdtddzrgdxshcx",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "bkrsdtddzrgdxshcxbkrsdtmn",
           "display": "bkrsdtddzrgdxshcxbkrsdtmn",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bukeraoshudetaduiduozhongrengedexushihuachengxian",
+          "display": "bukeraoshudetaduiduozhongrengedexushihuachengxian",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "bukeraoshudetaduiduozhongrengedexushihuachengxianbukeraoshudetamultiplicitynarrative",
@@ -912,236 +1774,6 @@
       ]
     },
     {
-      "path": "entries/Caregiver.md",
-      "title": "照顾者（Caregiver）",
-      "aliases": [
-        "Caregiver",
-        "照顾者（Caregiver）"
-      ],
-      "tokens": [
-        {
-          "normalized": "caregiver",
-          "display": "Caregiver",
-          "kind": "alias"
-        },
-        {
-          "normalized": "zgzc",
-          "display": "zgzc",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "zhaoguzhecaregiver",
-          "display": "zhaoguzhecaregiver",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "zhao gu zhe (caregiver)",
-          "display": "照顾者（Caregiver）",
-          "kind": "title"
-        },
-        {
-          "normalized": "zhaoguzhe(caregiver)",
-          "display": "照顾者（Caregiver）",
-          "kind": "title"
-        },
-        {
-          "normalized": "照顾者（caregiver）",
-          "display": "照顾者（Caregiver）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
-      "path": "entries/Co-Consciousness.md",
-      "title": "意识共存（Co-consciousness）",
-      "aliases": [
-        "Co-consciousness",
-        "意识共存（Co-consciousness）"
-      ],
-      "tokens": [
-        {
-          "normalized": "co-consciousness",
-          "display": "Co-consciousness",
-          "kind": "alias"
-        },
-        {
-          "normalized": "coconsciousness",
-          "display": "Co-consciousness",
-          "kind": "alias"
-        },
-        {
-          "normalized": "ysgccc",
-          "display": "ysgccc",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "yishigongcuncoconsciousness",
-          "display": "yishigongcuncoconsciousness",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "yi shi gong cun (co-consciousness)",
-          "display": "意识共存（Co-consciousness）",
-          "kind": "title"
-        },
-        {
-          "normalized": "yishigongcun(coconsciousness)",
-          "display": "意识共存（Co-consciousness）",
-          "kind": "title"
-        },
-        {
-          "normalized": "意识共存（co-consciousness）",
-          "display": "意识共存（Co-consciousness）",
-          "kind": "title"
-        },
-        {
-          "normalized": "意识共存（coconsciousness）",
-          "display": "意识共存（Co-consciousness）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
-      "path": "entries/Co-Fronting.md",
-      "title": "共前台（Co-fronting）",
-      "aliases": [
-        "Co-fronting",
-        "共前台（Co-fronting）"
-      ],
-      "tokens": [
-        {
-          "normalized": "co-fronting",
-          "display": "Co-fronting",
-          "kind": "alias"
-        },
-        {
-          "normalized": "cofronting",
-          "display": "Co-fronting",
-          "kind": "alias"
-        },
-        {
-          "normalized": "gqtcf",
-          "display": "gqtcf",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "gongqiantaicofronting",
-          "display": "gongqiantaicofronting",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "gong qian tai (co-fronting)",
-          "display": "共前台（Co-fronting）",
-          "kind": "title"
-        },
-        {
-          "normalized": "gongqiantai(cofronting)",
-          "display": "共前台（Co-fronting）",
-          "kind": "title"
-        },
-        {
-          "normalized": "共前台（co-fronting）",
-          "display": "共前台（Co-fronting）",
-          "kind": "title"
-        },
-        {
-          "normalized": "共前台（cofronting）",
-          "display": "共前台（Co-fronting）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
-      "path": "entries/Consciousness-Modification.md",
-      "title": "意识修改（Consciousness Modification）",
-      "aliases": [
-        "Consciousness Modification",
-        "意识修改（Consciousness Modification）"
-      ],
-      "tokens": [
-        {
-          "normalized": "consciousness modification",
-          "display": "Consciousness Modification",
-          "kind": "alias"
-        },
-        {
-          "normalized": "consciousnessmodification",
-          "display": "Consciousness Modification",
-          "kind": "alias"
-        },
-        {
-          "normalized": "ysxgcm",
-          "display": "ysxgcm",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "yishixiugaiconsciousnessmodification",
-          "display": "yishixiugaiconsciousnessmodification",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "yi shi xiu gai (consciousness modification)",
-          "display": "意识修改（Consciousness Modification）",
-          "kind": "title"
-        },
-        {
-          "normalized": "yishixiugai(consciousnessmodification)",
-          "display": "意识修改（Consciousness Modification）",
-          "kind": "title"
-        },
-        {
-          "normalized": "意识修改（consciousness modification）",
-          "display": "意识修改（Consciousness Modification）",
-          "kind": "title"
-        },
-        {
-          "normalized": "意识修改（consciousnessmodification）",
-          "display": "意识修改（Consciousness Modification）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
-      "path": "entries/Core.md",
-      "title": "核心（Core）",
-      "aliases": [
-        "Core",
-        "核心（Core）"
-      ],
-      "tokens": [
-        {
-          "normalized": "core",
-          "display": "Core",
-          "kind": "alias"
-        },
-        {
-          "normalized": "hxc",
-          "display": "hxc",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "hexincore",
-          "display": "hexincore",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "he xin (core)",
-          "display": "核心（Core）",
-          "kind": "title"
-        },
-        {
-          "normalized": "hexin(core)",
-          "display": "核心（Core）",
-          "kind": "title"
-        },
-        {
-          "normalized": "核心（core）",
-          "display": "核心（Core）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
       "path": "entries/CPTSD.md",
       "title": "复杂性创伤后应激障碍（CPTSD）",
       "aliases": [
@@ -1150,6 +1782,7 @@
         "Complex Post-Traumatic Stress Disorder",
         "fuzaxingchuangshanghouyingjizhangai",
         "复杂性创伤",
+        "复杂性创伤后应激障碍",
         "复杂性创伤后应激障碍（CPTSD）"
       ],
       "tokens": [
@@ -1159,8 +1792,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "fu za xing chuang shang hou ying ji zhang ai ",
+          "display": "复杂性创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fuzaxingchuangshanghouyingjizhangai",
+          "display": "复杂性创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "复杂性创伤后应激障碍",
+          "display": "复杂性创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
           "normalized": "fzxcs",
           "display": "fzxcs",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "fzxcshyjza",
+          "display": "fzxcshyjza",
           "kind": "pinyin_abbr"
         },
         {
@@ -1204,11 +1857,6 @@
           "kind": "synonym"
         },
         {
-          "normalized": "fuzaxingchuangshanghouyingjizhangai",
-          "display": "fuzaxingchuangshanghouyingjizhangai",
-          "kind": "synonym"
-        },
-        {
           "normalized": "复杂性创伤",
           "display": "复杂性创伤",
           "kind": "synonym"
@@ -1231,10 +1879,486 @@
       ]
     },
     {
+      "path": "entries/Caregiver.md",
+      "title": "照顾者（Caregiver）",
+      "aliases": [
+        "Caregiver",
+        "照顾者",
+        "照顾者（Caregiver）"
+      ],
+      "tokens": [
+        {
+          "normalized": "caregiver",
+          "display": "Caregiver",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhao gu zhe ",
+          "display": "照顾者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhaoguzhe",
+          "display": "照顾者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "照顾者",
+          "display": "照顾者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zgz",
+          "display": "zgz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zgzc",
+          "display": "zgzc",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zhaoguzhecaregiver",
+          "display": "zhaoguzhecaregiver",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "zhao gu zhe (caregiver)",
+          "display": "照顾者（Caregiver）",
+          "kind": "title"
+        },
+        {
+          "normalized": "zhaoguzhe(caregiver)",
+          "display": "照顾者（Caregiver）",
+          "kind": "title"
+        },
+        {
+          "normalized": "照顾者（caregiver）",
+          "display": "照顾者（Caregiver）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/Co-Consciousness.md",
+      "title": "意识共存（Co-consciousness）",
+      "aliases": [
+        "Co-consciousness",
+        "意识共存",
+        "意识共存（Co-consciousness）"
+      ],
+      "tokens": [
+        {
+          "normalized": "co-consciousness",
+          "display": "Co-consciousness",
+          "kind": "alias"
+        },
+        {
+          "normalized": "coconsciousness",
+          "display": "Co-consciousness",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yi shi gong cun ",
+          "display": "意识共存",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yishigongcun",
+          "display": "意识共存",
+          "kind": "alias"
+        },
+        {
+          "normalized": "意识共存",
+          "display": "意识共存",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ysgc",
+          "display": "ysgc",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "ysgccc",
+          "display": "ysgccc",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "yishigongcuncoconsciousness",
+          "display": "yishigongcuncoconsciousness",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "yi shi gong cun (co-consciousness)",
+          "display": "意识共存（Co-consciousness）",
+          "kind": "title"
+        },
+        {
+          "normalized": "yishigongcun(coconsciousness)",
+          "display": "意识共存（Co-consciousness）",
+          "kind": "title"
+        },
+        {
+          "normalized": "意识共存（co-consciousness）",
+          "display": "意识共存（Co-consciousness）",
+          "kind": "title"
+        },
+        {
+          "normalized": "意识共存（coconsciousness）",
+          "display": "意识共存（Co-consciousness）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/Co-Fronting.md",
+      "title": "共前台（Co-fronting）",
+      "aliases": [
+        "Co-fronting",
+        "共前台",
+        "共前台（Co-fronting）"
+      ],
+      "tokens": [
+        {
+          "normalized": "co-fronting",
+          "display": "Co-fronting",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cofronting",
+          "display": "Co-fronting",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gong qian tai ",
+          "display": "共前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gongqiantai",
+          "display": "共前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "共前台",
+          "display": "共前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gqt",
+          "display": "gqt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "gqtcf",
+          "display": "gqtcf",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "gongqiantaicofronting",
+          "display": "gongqiantaicofronting",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "gong qian tai (co-fronting)",
+          "display": "共前台（Co-fronting）",
+          "kind": "title"
+        },
+        {
+          "normalized": "gongqiantai(cofronting)",
+          "display": "共前台（Co-fronting）",
+          "kind": "title"
+        },
+        {
+          "normalized": "共前台（co-fronting）",
+          "display": "共前台（Co-fronting）",
+          "kind": "title"
+        },
+        {
+          "normalized": "共前台（cofronting）",
+          "display": "共前台（Co-fronting）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/Consciousness-Modification.md",
+      "title": "意识修改（Consciousness Modification）",
+      "aliases": [
+        "Consciousness Modification",
+        "意识修改",
+        "意识修改（Consciousness Modification）"
+      ],
+      "tokens": [
+        {
+          "normalized": "consciousness modification",
+          "display": "Consciousness Modification",
+          "kind": "alias"
+        },
+        {
+          "normalized": "consciousnessmodification",
+          "display": "Consciousness Modification",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yi shi xiu gai ",
+          "display": "意识修改",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yishixiugai",
+          "display": "意识修改",
+          "kind": "alias"
+        },
+        {
+          "normalized": "意识修改",
+          "display": "意识修改",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ysxg",
+          "display": "ysxg",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "ysxgcm",
+          "display": "ysxgcm",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "yishixiugaiconsciousnessmodification",
+          "display": "yishixiugaiconsciousnessmodification",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "yi shi xiu gai (consciousness modification)",
+          "display": "意识修改（Consciousness Modification）",
+          "kind": "title"
+        },
+        {
+          "normalized": "yishixiugai(consciousnessmodification)",
+          "display": "意识修改（Consciousness Modification）",
+          "kind": "title"
+        },
+        {
+          "normalized": "意识修改（consciousness modification）",
+          "display": "意识修改（Consciousness Modification）",
+          "kind": "title"
+        },
+        {
+          "normalized": "意识修改（consciousnessmodification）",
+          "display": "意识修改（Consciousness Modification）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/Core.md",
+      "title": "核心（Core）",
+      "aliases": [
+        "Core",
+        "核心",
+        "核心（Core）"
+      ],
+      "tokens": [
+        {
+          "normalized": "core",
+          "display": "Core",
+          "kind": "alias"
+        },
+        {
+          "normalized": "he xin ",
+          "display": "核心",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hexin",
+          "display": "核心",
+          "kind": "alias"
+        },
+        {
+          "normalized": "核心",
+          "display": "核心",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hx",
+          "display": "hx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hxc",
+          "display": "hxc",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hexincore",
+          "display": "hexincore",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "he xin (core)",
+          "display": "核心（Core）",
+          "kind": "title"
+        },
+        {
+          "normalized": "hexin(core)",
+          "display": "核心（Core）",
+          "kind": "title"
+        },
+        {
+          "normalized": "核心（core）",
+          "display": "核心（Core）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/DID.md",
+      "title": "解离性身份障碍（Dissociative Identity Disorder，DID）",
+      "aliases": [
+        "DID",
+        "DID）",
+        "Dissociative Identity Disorder",
+        "Dissociative Identity Disorder，DID",
+        "解离性身份障碍",
+        "解离性身份障碍（Dissociative Identity Disorder",
+        "解离性身份障碍（Dissociative Identity Disorder，DID）"
+      ],
+      "tokens": [
+        {
+          "normalized": "did",
+          "display": "DID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "did)",
+          "display": "DID）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "did）",
+          "display": "DID）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociative identity disorder",
+          "display": "Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociative identity disorder,did",
+          "display": "Dissociative Identity Disorder，DID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociative identity disorder，did",
+          "display": "Dissociative Identity Disorder，DID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociativeidentitydisorder",
+          "display": "Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociativeidentitydisorder,did",
+          "display": "Dissociative Identity Disorder，DID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociativeidentitydisorder，did",
+          "display": "Dissociative Identity Disorder，DID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jie chi xing shen fen zhang ai ",
+          "display": "解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jie chi xing shen fen zhang ai (dissociative identity disorder",
+          "display": "解离性身份障碍（Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiechixingshenfenzhangai",
+          "display": "解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiechixingshenfenzhangai(dissociativeidentitydisorder",
+          "display": "解离性身份障碍（Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性身份障碍",
+          "display": "解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性身份障碍（dissociative identity disorder",
+          "display": "解离性身份障碍（Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性身份障碍（dissociativeidentitydisorder",
+          "display": "解离性身份障碍（Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jcxsfza",
+          "display": "jcxsfza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jcxsfzadid",
+          "display": "jcxsfzadid",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jcxsfzadidd",
+          "display": "jcxsfzadidd",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jiechixingshenfenzhangaidissociativeidentitydisorder",
+          "display": "jiechixingshenfenzhangaidissociativeidentitydisorder",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "jiechixingshenfenzhangaidissociativeidentitydisorderdid",
+          "display": "jiechixingshenfenzhangaidissociativeidentitydisorderdid",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "jie chi xing shen fen zhang ai (dissociative identity disorder,did)",
+          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
+          "kind": "title"
+        },
+        {
+          "normalized": "jiechixingshenfenzhangai(dissociativeidentitydisorder,did)",
+          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
+          "kind": "title"
+        },
+        {
+          "normalized": "解离性身份障碍（dissociative identity disorder，did）",
+          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
+          "kind": "title"
+        },
+        {
+          "normalized": "解离性身份障碍（dissociativeidentitydisorder，did）",
+          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
       "path": "entries/Delirium.md",
       "title": "谵妄（Delirium）",
       "aliases": [
         "Delirium",
+        "谵妄",
         "谵妄（Delirium）"
       ],
       "tokens": [
@@ -1242,6 +2366,26 @@
           "normalized": "delirium",
           "display": "Delirium",
           "kind": "alias"
+        },
+        {
+          "normalized": "zhan wang ",
+          "display": "谵妄",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhanwang",
+          "display": "谵妄",
+          "kind": "alias"
+        },
+        {
+          "normalized": "谵妄",
+          "display": "谵妄",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zw",
+          "display": "zw",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zwd",
@@ -1275,14 +2419,40 @@
       "title": "人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）",
       "aliases": [
         "DPDR",
+        "DPDR）",
         "Depersonalization",
+        "Depersonalization/Derealization Disorder，DPDR",
         "Derealization Disorder",
-        "人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）"
+        "人格解体",
+        "人格解体/现实解体障碍",
+        "人格解体/现实解体障碍（Depersonalization/Derealization Disorder，DPDR）",
+        "现实解体障碍",
+        "现实解体障碍（Depersonalization"
       ],
       "tokens": [
         {
           "normalized": "depersonalization",
           "display": "Depersonalization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "depersonalization/derealization disorder,dpdr",
+          "display": "Depersonalization/Derealization Disorder，DPDR",
+          "kind": "alias"
+        },
+        {
+          "normalized": "depersonalization/derealization disorder，dpdr",
+          "display": "Depersonalization/Derealization Disorder，DPDR",
+          "kind": "alias"
+        },
+        {
+          "normalized": "depersonalizationderealizationdisorder,dpdr",
+          "display": "Depersonalization/Derealization Disorder，DPDR",
+          "kind": "alias"
+        },
+        {
+          "normalized": "depersonalizationderealizationdisorder，dpdr",
+          "display": "Depersonalization/Derealization Disorder，DPDR",
           "kind": "alias"
         },
         {
@@ -1301,13 +2471,113 @@
           "kind": "alias"
         },
         {
+          "normalized": "dpdr)",
+          "display": "DPDR）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dpdr）",
+          "display": "DPDR）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ren ge jie ti ",
+          "display": "人格解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ren ge jie ti /xian shi jie ti zhang ai ",
+          "display": "人格解体/现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rengejieti",
+          "display": "人格解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rengejietixianshijietizhangai",
+          "display": "人格解体/现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xian shi jie ti zhang ai ",
+          "display": "现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xian shi jie ti zhang ai (depersonalization",
+          "display": "现实解体障碍（Depersonalization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianshijietizhangai",
+          "display": "现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianshijietizhangai(depersonalization",
+          "display": "现实解体障碍（Depersonalization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "人格解体",
+          "display": "人格解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "人格解体/现实解体障碍",
+          "display": "人格解体/现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "人格解体现实解体障碍",
+          "display": "人格解体/现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "现实解体障碍",
+          "display": "现实解体障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "现实解体障碍（depersonalization",
+          "display": "现实解体障碍（Depersonalization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rgjt",
+          "display": "rgjt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "rgjtxsjtza",
+          "display": "rgjtxsjtza",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "rgjtxsjtzadddd",
           "display": "rgjtxsjtzadddd",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "xsjtza",
+          "display": "xsjtza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xsjtzad",
+          "display": "xsjtzad",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "rengejietixianshijietizhangaidepersonalizationderealizationdisorderdpdr",
           "display": "rengejietixianshijietizhangaidepersonalizationderealizationdisorderdpdr",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "xianshijietizhangaidepersonalization",
+          "display": "xianshijietizhangaidepersonalization",
           "kind": "pinyin_full"
         },
         {
@@ -1337,6 +2607,7 @@
       "title": "非我感（Depersonalization）",
       "aliases": [
         "Depersonalization",
+        "非我感",
         "非我感（Depersonalization）"
       ],
       "tokens": [
@@ -1344,6 +2615,26 @@
           "normalized": "depersonalization",
           "display": "Depersonalization",
           "kind": "alias"
+        },
+        {
+          "normalized": "fei wo gan ",
+          "display": "非我感",
+          "kind": "alias"
+        },
+        {
+          "normalized": "feiwogan",
+          "display": "非我感",
+          "kind": "alias"
+        },
+        {
+          "normalized": "非我感",
+          "display": "非我感",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fwg",
+          "display": "fwg",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "fwgd",
@@ -1377,6 +2668,7 @@
       "title": "抑郁障碍（Depressive Disorders）",
       "aliases": [
         "Depressive Disorders",
+        "抑郁障碍",
         "抑郁障碍（Depressive Disorders）"
       ],
       "tokens": [
@@ -1389,6 +2681,26 @@
           "normalized": "depressivedisorders",
           "display": "Depressive Disorders",
           "kind": "alias"
+        },
+        {
+          "normalized": "yi yu zhang ai ",
+          "display": "抑郁障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yiyuzhangai",
+          "display": "抑郁障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "抑郁障碍",
+          "display": "抑郁障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yyza",
+          "display": "yyza",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "yyzadd",
@@ -1427,6 +2739,7 @@
       "title": "去现实化（Derealization）",
       "aliases": [
         "Derealization",
+        "去现实化",
         "去现实化（Derealization）"
       ],
       "tokens": [
@@ -1434,6 +2747,26 @@
           "normalized": "derealization",
           "display": "Derealization",
           "kind": "alias"
+        },
+        {
+          "normalized": "qu xian shi hua ",
+          "display": "去现实化",
+          "kind": "alias"
+        },
+        {
+          "normalized": "quxianshihua",
+          "display": "去现实化",
+          "kind": "alias"
+        },
+        {
+          "normalized": "去现实化",
+          "display": "去现实化",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qxsh",
+          "display": "qxsh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qxshd",
@@ -1463,73 +2796,38 @@
       ]
     },
     {
-      "path": "entries/DID.md",
-      "title": "解离性身份障碍（Dissociative Identity Disorder，DID）",
-      "aliases": [
-        "DID",
-        "Dissociative Identity Disorder",
-        "解离性身份障碍（Dissociative Identity Disorder，DID）"
-      ],
-      "tokens": [
-        {
-          "normalized": "did",
-          "display": "DID",
-          "kind": "alias"
-        },
-        {
-          "normalized": "dissociative identity disorder",
-          "display": "Dissociative Identity Disorder",
-          "kind": "alias"
-        },
-        {
-          "normalized": "dissociativeidentitydisorder",
-          "display": "Dissociative Identity Disorder",
-          "kind": "alias"
-        },
-        {
-          "normalized": "jcxsfzadidd",
-          "display": "jcxsfzadidd",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "jiechixingshenfenzhangaidissociativeidentitydisorderdid",
-          "display": "jiechixingshenfenzhangaidissociativeidentitydisorderdid",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "jie chi xing shen fen zhang ai (dissociative identity disorder,did)",
-          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
-          "kind": "title"
-        },
-        {
-          "normalized": "jiechixingshenfenzhangai(dissociativeidentitydisorder,did)",
-          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
-          "kind": "title"
-        },
-        {
-          "normalized": "解离性身份障碍（dissociative identity disorder，did）",
-          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
-          "kind": "title"
-        },
-        {
-          "normalized": "解离性身份障碍（dissociativeidentitydisorder，did）",
-          "display": "解离性身份障碍（Dissociative Identity Disorder，DID）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
       "path": "entries/Disorientation.md",
       "title": "定向障碍（Disorientation）",
       "aliases": [
         "Disorientation",
+        "定向障碍",
         "定向障碍（Disorientation）"
       ],
       "tokens": [
         {
+          "normalized": "ding xiang zhang ai ",
+          "display": "定向障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dingxiangzhangai",
+          "display": "定向障碍",
+          "kind": "alias"
+        },
+        {
           "normalized": "disorientation",
           "display": "Disorientation",
           "kind": "alias"
+        },
+        {
+          "normalized": "定向障碍",
+          "display": "定向障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dxza",
+          "display": "dxza",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "dxzad",
@@ -1563,6 +2861,7 @@
       "title": "解离（Dissociation）",
       "aliases": [
         "Dissociation",
+        "解离",
         "解离（Dissociation）"
       ],
       "tokens": [
@@ -1570,6 +2869,26 @@
           "normalized": "dissociation",
           "display": "Dissociation",
           "kind": "alias"
+        },
+        {
+          "normalized": "jie chi ",
+          "display": "解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiechi",
+          "display": "解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离",
+          "display": "解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jc",
+          "display": "jc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jcd",
@@ -1603,7 +2922,11 @@
       "title": "解离性遗忘（Dissociative Amnesia，DA）",
       "aliases": [
         "DA",
+        "DA）",
         "Dissociative Amnesia",
+        "Dissociative Amnesia，DA",
+        "解离性遗忘",
+        "解离性遗忘（Dissociative Amnesia",
         "解离性遗忘（Dissociative Amnesia，DA）"
       ],
       "tokens": [
@@ -1613,8 +2936,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "da)",
+          "display": "DA）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "da）",
+          "display": "DA）",
+          "kind": "alias"
+        },
+        {
           "normalized": "dissociative amnesia",
           "display": "Dissociative Amnesia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociative amnesia,da",
+          "display": "Dissociative Amnesia，DA",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociative amnesia，da",
+          "display": "Dissociative Amnesia，DA",
           "kind": "alias"
         },
         {
@@ -1623,9 +2966,69 @@
           "kind": "alias"
         },
         {
+          "normalized": "dissociativeamnesia,da",
+          "display": "Dissociative Amnesia，DA",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dissociativeamnesia，da",
+          "display": "Dissociative Amnesia，DA",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jie chi xing yi wang ",
+          "display": "解离性遗忘",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jie chi xing yi wang (dissociative amnesia",
+          "display": "解离性遗忘（Dissociative Amnesia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiechixingyiwang",
+          "display": "解离性遗忘",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiechixingyiwang(dissociativeamnesia",
+          "display": "解离性遗忘（Dissociative Amnesia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性遗忘",
+          "display": "解离性遗忘",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性遗忘（dissociative amnesia",
+          "display": "解离性遗忘（Dissociative Amnesia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "解离性遗忘（dissociativeamnesia",
+          "display": "解离性遗忘（Dissociative Amnesia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jcxyw",
+          "display": "jcxyw",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jcxywda",
+          "display": "jcxywda",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "jcxywdad",
           "display": "jcxywdad",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jiechixingyiwangdissociativeamnesia",
+          "display": "jiechixingyiwangdissociativeamnesia",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "jiechixingyiwangdissociativeamnesiada",
@@ -1659,6 +3062,7 @@
       "title": "陀思妥耶夫斯基《双重人格》（The Double）与自我分裂",
       "aliases": [
         "The Double",
+        "陀思妥耶夫斯基《双重人格》 与自我分裂",
         "陀思妥耶夫斯基《双重人格》（The Double）与自我分裂"
       ],
       "tokens": [
@@ -1673,13 +3077,43 @@
           "kind": "alias"
         },
         {
+          "normalized": "tuo si tuo ye fu si ji <<shuang zhong ren ge >>  yu zi wo fen lie ",
+          "display": "陀思妥耶夫斯基《双重人格》 与自我分裂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "tuosituoyefusiji<<shuangzhongrenge>>yuziwofenlie",
+          "display": "陀思妥耶夫斯基《双重人格》 与自我分裂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "陀思妥耶夫斯基《双重人格》 与自我分裂",
+          "display": "陀思妥耶夫斯基《双重人格》 与自我分裂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "陀思妥耶夫斯基《双重人格》与自我分裂",
+          "display": "陀思妥耶夫斯基《双重人格》 与自我分裂",
+          "kind": "alias"
+        },
+        {
           "normalized": "tstyfsjszrgtdyzwfl",
           "display": "tstyfsjszrgtdyzwfl",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "tstyfsjszrgyzwfl",
+          "display": "tstyfsjszrgyzwfl",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "tuosituoyefusijishuangzhongrengethedoubleyuziwofenlie",
           "display": "tuosituoyefusijishuangzhongrengethedoubleyuziwofenlie",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "tuosituoyefusijishuangzhongrengeyuziwofenlie",
+          "display": "tuosituoyefusijishuangzhongrengeyuziwofenlie",
           "kind": "pinyin_full"
         },
         {
@@ -1709,9 +3143,20 @@
       "title": "埃蒙加德分类法（Emmengard Classification）",
       "aliases": [
         "Emmengard Classification",
+        "埃蒙加德分类法",
         "埃蒙加德分类法（Emmengard Classification）"
       ],
       "tokens": [
+        {
+          "normalized": "ai meng jia de fen lei fa ",
+          "display": "埃蒙加德分类法",
+          "kind": "alias"
+        },
+        {
+          "normalized": "aimengjiadefenleifa",
+          "display": "埃蒙加德分类法",
+          "kind": "alias"
+        },
         {
           "normalized": "emmengard classification",
           "display": "Emmengard Classification",
@@ -1721,6 +3166,16 @@
           "normalized": "emmengardclassification",
           "display": "Emmengard Classification",
           "kind": "alias"
+        },
+        {
+          "normalized": "埃蒙加德分类法",
+          "display": "埃蒙加德分类法",
+          "kind": "alias"
+        },
+        {
+          "normalized": "amjdflf",
+          "display": "amjdflf",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "amjdflfec",
@@ -1759,13 +3214,34 @@
       "title": "独有记忆（Exomemory）",
       "aliases": [
         "Exomemory",
+        "独有记忆",
         "独有记忆（Exomemory）"
       ],
       "tokens": [
         {
+          "normalized": "du you ji yi ",
+          "display": "独有记忆",
+          "kind": "alias"
+        },
+        {
+          "normalized": "duyoujiyi",
+          "display": "独有记忆",
+          "kind": "alias"
+        },
+        {
           "normalized": "exomemory",
           "display": "Exomemory",
           "kind": "alias"
+        },
+        {
+          "normalized": "独有记忆",
+          "display": "独有记忆",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dyjy",
+          "display": "dyjy",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "dyjye",
@@ -1799,6 +3275,7 @@
       "title": "外投射（External Projection）",
       "aliases": [
         "External Projection",
+        "外投射",
         "外投射（External Projection）"
       ],
       "tokens": [
@@ -1811,6 +3288,26 @@
           "normalized": "externalprojection",
           "display": "External Projection",
           "kind": "alias"
+        },
+        {
+          "normalized": "wai tou she ",
+          "display": "外投射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "waitoushe",
+          "display": "外投射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "外投射",
+          "display": "外投射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "wts",
+          "display": "wts",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "wtsep",
@@ -1849,7 +3346,11 @@
       "title": "家族式系统（Family Systems, Xianyu Theory）",
       "aliases": [
         "Family Systems",
+        "Family Systems, Xianyu Theory",
         "Xianyu Theory",
+        "Xianyu Theory）",
+        "家族式系统",
+        "家族式系统（Family Systems",
         "家族式系统（Family Systems, Xianyu Theory）"
       ],
       "tokens": [
@@ -1859,8 +3360,38 @@
           "kind": "alias"
         },
         {
+          "normalized": "family systems, xianyu theory",
+          "display": "Family Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
           "normalized": "familysystems",
           "display": "Family Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "familysystems,xianyutheory",
+          "display": "Family Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jia zu shi xi tong ",
+          "display": "家族式系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jia zu shi xi tong (family systems",
+          "display": "家族式系统（Family Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiazushixitong",
+          "display": "家族式系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiazushixitong(familysystems",
+          "display": "家族式系统（Family Systems",
           "kind": "alias"
         },
         {
@@ -1869,14 +3400,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "xianyu theory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
           "normalized": "xianyutheory",
           "display": "Xianyu Theory",
           "kind": "alias"
         },
         {
+          "normalized": "xianyutheory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyutheory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "家族式系统",
+          "display": "家族式系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "家族式系统（family systems",
+          "display": "家族式系统（Family Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "家族式系统（familysystems",
+          "display": "家族式系统（Family Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jzsxt",
+          "display": "jzsxt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jzsxtfs",
+          "display": "jzsxtfs",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "jzsxtfsxt",
           "display": "jzsxtfsxt",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jiazushixitongfamilysystems",
+          "display": "jiazushixitongfamilysystems",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "jiazushixitongfamilysystemsxianyutheory",
@@ -1910,6 +3491,7 @@
       "title": "伪主体（Fauxmain）",
       "aliases": [
         "Fauxmain",
+        "伪主体",
         "伪主体（Fauxmain）"
       ],
       "tokens": [
@@ -1917,6 +3499,26 @@
           "normalized": "fauxmain",
           "display": "Fauxmain",
           "kind": "alias"
+        },
+        {
+          "normalized": "wei zhu ti ",
+          "display": "伪主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "weizhuti",
+          "display": "伪主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "伪主体",
+          "display": "伪主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "wzt",
+          "display": "wzt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "wztf",
@@ -1950,7 +3552,11 @@
       "title": "《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻",
       "aliases": [
         "1999",
+        "1999）与身份解体隐喻",
         "Fight Club",
+        "Fight Club, 1999",
+        "《搏击俱乐部》 与身份解体隐喻",
+        "《搏击俱乐部》（Fight Club",
         "《搏击俱乐部》（Fight Club, 1999）与身份解体隐喻"
       ],
       "tokens": [
@@ -1960,8 +3566,48 @@
           "kind": "alias"
         },
         {
+          "normalized": "1999)yu shen fen jie ti yin yu ",
+          "display": "1999）与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1999)yushenfenjietiyinyu",
+          "display": "1999）与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1999）与身份解体隐喻",
+          "display": "1999）与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bo ji ju le bu >>  yu shen fen jie ti yin yu ",
+          "display": "《搏击俱乐部》 与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bo ji ju le bu >> (fight club",
+          "display": "《搏击俱乐部》（Fight Club",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bojijulebu>>(fightclub",
+          "display": "《搏击俱乐部》（Fight Club",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bojijulebu>>yushenfenjietiyinyu",
+          "display": "《搏击俱乐部》 与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
           "normalized": "fight club",
           "display": "Fight Club",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fight club, 1999",
+          "display": "Fight Club, 1999",
           "kind": "alias"
         },
         {
@@ -1970,13 +3616,68 @@
           "kind": "alias"
         },
         {
+          "normalized": "fightclub,1999",
+          "display": "Fight Club, 1999",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《搏击俱乐部》 与身份解体隐喻",
+          "display": "《搏击俱乐部》 与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《搏击俱乐部》与身份解体隐喻",
+          "display": "《搏击俱乐部》 与身份解体隐喻",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《搏击俱乐部》（fight club",
+          "display": "《搏击俱乐部》（Fight Club",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《搏击俱乐部》（fightclub",
+          "display": "《搏击俱乐部》（Fight Club",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bjjlbfc",
+          "display": "bjjlbfc",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "bjjlbfcysfjtyy",
           "display": "bjjlbfcysfjtyy",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "bjjlbysfjtyy",
+          "display": "bjjlbysfjtyy",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "ysfjtyy",
+          "display": "ysfjtyy",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "1999yushenfenjietiyinyu",
+          "display": "1999yushenfenjietiyinyu",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "bojijulebufightclub",
+          "display": "bojijulebufightclub",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "bojijulebufightclub1999yushenfenjietiyinyu",
           "display": "bojijulebufightclub1999yushenfenjietiyinyu",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "bojijulebuyushenfenjietiyinyu",
+          "display": "bojijulebuyushenfenjietiyinyu",
           "kind": "pinyin_full"
         },
         {
@@ -2006,6 +3707,7 @@
       "title": "闪回（Flashback）",
       "aliases": [
         "Flashback",
+        "闪回",
         "闪回（Flashback）"
       ],
       "tokens": [
@@ -2013,6 +3715,26 @@
           "normalized": "flashback",
           "display": "Flashback",
           "kind": "alias"
+        },
+        {
+          "normalized": "shan hui ",
+          "display": "闪回",
+          "kind": "alias"
+        },
+        {
+          "normalized": "shanhui",
+          "display": "闪回",
+          "kind": "alias"
+        },
+        {
+          "normalized": "闪回",
+          "display": "闪回",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sh",
+          "display": "sh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "shf",
@@ -2046,6 +3768,7 @@
       "title": "碎片（Fragment）",
       "aliases": [
         "Fragment",
+        "碎片",
         "碎片（Fragment）"
       ],
       "tokens": [
@@ -2053,6 +3776,26 @@
           "normalized": "fragment",
           "display": "Fragment",
           "kind": "alias"
+        },
+        {
+          "normalized": "sui pian ",
+          "display": "碎片",
+          "kind": "alias"
+        },
+        {
+          "normalized": "suipian",
+          "display": "碎片",
+          "kind": "alias"
+        },
+        {
+          "normalized": "碎片",
+          "display": "碎片",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sp",
+          "display": "sp",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "spf",
@@ -2086,7 +3829,11 @@
       "title": "前台（Front / Fronting）",
       "aliases": [
         "Front",
+        "Front / Fronting",
         "Fronting",
+        "Fronting）",
+        "前台",
+        "前台（Front",
         "前台（Front / Fronting）"
       ],
       "tokens": [
@@ -2096,14 +3843,79 @@
           "kind": "alias"
         },
         {
+          "normalized": "front / fronting",
+          "display": "Front / Fronting",
+          "kind": "alias"
+        },
+        {
+          "normalized": "frontfronting",
+          "display": "Front / Fronting",
+          "kind": "alias"
+        },
+        {
           "normalized": "fronting",
           "display": "Fronting",
           "kind": "alias"
         },
         {
+          "normalized": "fronting)",
+          "display": "Fronting）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fronting）",
+          "display": "Fronting）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qian tai ",
+          "display": "前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qian tai (front",
+          "display": "前台（Front",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiantai",
+          "display": "前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiantai(front",
+          "display": "前台（Front",
+          "kind": "alias"
+        },
+        {
+          "normalized": "前台",
+          "display": "前台",
+          "kind": "alias"
+        },
+        {
+          "normalized": "前台（front",
+          "display": "前台（Front",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qt",
+          "display": "qt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qtf",
+          "display": "qtf",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "qtff",
           "display": "qtff",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qiantaifront",
+          "display": "qiantaifront",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "qiantaifrontfronting",
@@ -2137,6 +3949,7 @@
       "title": "功能性分离（Functional Dissociation）",
       "aliases": [
         "Functional Dissociation",
+        "功能性分离",
         "功能性分离（Functional Dissociation）"
       ],
       "tokens": [
@@ -2149,6 +3962,26 @@
           "normalized": "functionaldissociation",
           "display": "Functional Dissociation",
           "kind": "alias"
+        },
+        {
+          "normalized": "gong neng xing fen chi ",
+          "display": "功能性分离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gongnengxingfenchi",
+          "display": "功能性分离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "功能性分离",
+          "display": "功能性分离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gnxfc",
+          "display": "gnxfc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "gnxfcfd",
@@ -2187,6 +4020,7 @@
       "title": "融合（Fusion）",
       "aliases": [
         "Fusion",
+        "融合",
         "融合（Fusion）"
       ],
       "tokens": [
@@ -2194,6 +4028,26 @@
           "normalized": "fusion",
           "display": "Fusion",
           "kind": "alias"
+        },
+        {
+          "normalized": "rong he ",
+          "display": "融合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ronghe",
+          "display": "融合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "融合",
+          "display": "融合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rh",
+          "display": "rh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "rhf",
@@ -2227,6 +4081,7 @@
       "title": "守门人（Gatekeeper）",
       "aliases": [
         "Gatekeeper",
+        "守门人",
         "守门人（Gatekeeper）"
       ],
       "tokens": [
@@ -2234,6 +4089,26 @@
           "normalized": "gatekeeper",
           "display": "Gatekeeper",
           "kind": "alias"
+        },
+        {
+          "normalized": "shou men ren ",
+          "display": "守门人",
+          "kind": "alias"
+        },
+        {
+          "normalized": "shoumenren",
+          "display": "守门人",
+          "kind": "alias"
+        },
+        {
+          "normalized": "守门人",
+          "display": "守门人",
+          "kind": "alias"
+        },
+        {
+          "normalized": "smr",
+          "display": "smr",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "smrg",
@@ -2267,6 +4142,7 @@
       "title": "接地（Grounding）",
       "aliases": [
         "Grounding",
+        "接地",
         "接地（Grounding）"
       ],
       "tokens": [
@@ -2274,6 +4150,26 @@
           "normalized": "grounding",
           "display": "Grounding",
           "kind": "alias"
+        },
+        {
+          "normalized": "jie di ",
+          "display": "接地",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiedi",
+          "display": "接地",
+          "kind": "alias"
+        },
+        {
+          "normalized": "接地",
+          "display": "接地",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jd",
+          "display": "jd",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jdg",
@@ -2307,6 +4203,7 @@
       "title": "虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）",
       "aliases": [
         "Hatsune Miku Virtual Idol Tulpa Boundary",
+        "虚拟偶像与 Tulpa 的边界：初音未来现象",
         "虚拟偶像与 Tulpa 的边界：初音未来现象（Hatsune Miku Virtual Idol Tulpa Boundary）"
       ],
       "tokens": [
@@ -2321,9 +4218,39 @@
           "kind": "alias"
         },
         {
+          "normalized": "xu ni ou xiang yu  tulpa de bian jie :chu yin wei lai xian xiang ",
+          "display": "虚拟偶像与 Tulpa 的边界：初音未来现象",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xuniouxiangyutulpadebianjie:chuyinweilaixianxiang",
+          "display": "虚拟偶像与 Tulpa 的边界：初音未来现象",
+          "kind": "alias"
+        },
+        {
+          "normalized": "虚拟偶像与 tulpa 的边界：初音未来现象",
+          "display": "虚拟偶像与 Tulpa 的边界：初音未来现象",
+          "kind": "alias"
+        },
+        {
+          "normalized": "虚拟偶像与tulpa的边界：初音未来现象",
+          "display": "虚拟偶像与 Tulpa 的边界：初音未来现象",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xnoxytdbjcywlxx",
+          "display": "xnoxytdbjcywlxx",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "xnoxytdbjcywlxxhmvitb",
           "display": "xnoxytdbjcywlxxhmvitb",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xuniouxiangyutulpadebianjiechuyinweilaixianxiang",
+          "display": "xuniouxiangyutulpadebianjiechuyinweilaixianxiang",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "xuniouxiangyutulpadebianjiechuyinweilaixianxianghatsunemikuvirtualidoltulpaboundary",
@@ -2357,6 +4284,7 @@
       "title": "头压（Head Pressure）",
       "aliases": [
         "Head Pressure",
+        "头压",
         "头压（Head Pressure）"
       ],
       "tokens": [
@@ -2369,6 +4297,26 @@
           "normalized": "headpressure",
           "display": "Head Pressure",
           "kind": "alias"
+        },
+        {
+          "normalized": "tou ya ",
+          "display": "头压",
+          "kind": "alias"
+        },
+        {
+          "normalized": "touya",
+          "display": "头压",
+          "kind": "alias"
+        },
+        {
+          "normalized": "头压",
+          "display": "头压",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ty",
+          "display": "ty",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "tyhp",
@@ -2407,7 +4355,11 @@
       "title": "内部空间（Headspace / Inner World）",
       "aliases": [
         "Headspace",
+        "Headspace / Inner World",
         "Inner World",
+        "Inner World）",
+        "内部空间",
+        "内部空间（Headspace",
         "内部空间（Headspace / Inner World）"
       ],
       "tokens": [
@@ -2417,8 +4369,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "headspace / inner world",
+          "display": "Headspace / Inner World",
+          "kind": "alias"
+        },
+        {
+          "normalized": "headspaceinnerworld",
+          "display": "Headspace / Inner World",
+          "kind": "alias"
+        },
+        {
           "normalized": "inner world",
           "display": "Inner World",
+          "kind": "alias"
+        },
+        {
+          "normalized": "inner world)",
+          "display": "Inner World）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "inner world）",
+          "display": "Inner World）",
           "kind": "alias"
         },
         {
@@ -2427,9 +4399,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "innerworld)",
+          "display": "Inner World）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "innerworld）",
+          "display": "Inner World）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei bu kong jian ",
+          "display": "内部空间",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei bu kong jian (headspace",
+          "display": "内部空间（Headspace",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neibukongjian",
+          "display": "内部空间",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neibukongjian(headspace",
+          "display": "内部空间（Headspace",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部空间",
+          "display": "内部空间",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部空间（headspace",
+          "display": "内部空间（Headspace",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nbkj",
+          "display": "nbkj",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "nbkjh",
+          "display": "nbkjh",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "nbkjhiw",
           "display": "nbkjhiw",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "neibukongjianheadspace",
+          "display": "neibukongjianheadspace",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "neibukongjianheadspaceinnerworld",
@@ -2463,6 +4490,7 @@
       "title": "宿主（Host）",
       "aliases": [
         "Host",
+        "宿主",
         "宿主（Host）"
       ],
       "tokens": [
@@ -2470,6 +4498,26 @@
           "normalized": "host",
           "display": "Host",
           "kind": "alias"
+        },
+        {
+          "normalized": "su zhu ",
+          "display": "宿主",
+          "kind": "alias"
+        },
+        {
+          "normalized": "suzhu",
+          "display": "宿主",
+          "kind": "alias"
+        },
+        {
+          "normalized": "宿主",
+          "display": "宿主",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sz",
+          "display": "sz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "szh",
@@ -2503,6 +4551,7 @@
       "title": "医源型系统（Iatrogenic System）",
       "aliases": [
         "Iatrogenic System",
+        "医源型系统",
         "医源型系统（Iatrogenic System）"
       ],
       "tokens": [
@@ -2515,6 +4564,26 @@
           "normalized": "iatrogenicsystem",
           "display": "Iatrogenic System",
           "kind": "alias"
+        },
+        {
+          "normalized": "yi yuan xing xi tong ",
+          "display": "医源型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yiyuanxingxitong",
+          "display": "医源型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "医源型系统",
+          "display": "医源型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yyxxt",
+          "display": "yyxxt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "yyxxtis",
@@ -2553,9 +4622,20 @@
       "title": "幻想伙伴（Imaginary Companion）",
       "aliases": [
         "Imaginary Companion",
+        "幻想伙伴",
         "幻想伙伴（Imaginary Companion）"
       ],
       "tokens": [
+        {
+          "normalized": "huan xiang huo ban ",
+          "display": "幻想伙伴",
+          "kind": "alias"
+        },
+        {
+          "normalized": "huanxianghuoban",
+          "display": "幻想伙伴",
+          "kind": "alias"
+        },
         {
           "normalized": "imaginary companion",
           "display": "Imaginary Companion",
@@ -2565,6 +4645,16 @@
           "normalized": "imaginarycompanion",
           "display": "Imaginary Companion",
           "kind": "alias"
+        },
+        {
+          "normalized": "幻想伙伴",
+          "display": "幻想伙伴",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hxhb",
+          "display": "hxhb",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "hxhbic",
@@ -2603,13 +4693,35 @@
       "title": "独立性（Independence）",
       "aliases": [
         "Independence",
-        "独立性（Independence）"
+        "独立性",
+        "独立性（Independence）",
+        "独立意识"
       ],
       "tokens": [
+        {
+          "normalized": "du li xing ",
+          "display": "独立性",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dulixing",
+          "display": "独立性",
+          "kind": "alias"
+        },
         {
           "normalized": "independence",
           "display": "Independence",
           "kind": "alias"
+        },
+        {
+          "normalized": "独立性",
+          "display": "独立性",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dlx",
+          "display": "dlx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "dlxi",
@@ -2617,9 +4729,29 @@
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "dlys",
+          "display": "dlys",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "dulixingindependence",
           "display": "dulixingindependence",
           "kind": "pinyin_full"
+        },
+        {
+          "normalized": "du li yi shi ",
+          "display": "独立意识",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "duliyishi",
+          "display": "独立意识",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "独立意识",
+          "display": "独立意识",
+          "kind": "synonym"
         },
         {
           "normalized": "du li xing (independence)",
@@ -2643,6 +4775,7 @@
       "title": "整合（Integration）",
       "aliases": [
         "Integration",
+        "整合",
         "整合（Integration）"
       ],
       "tokens": [
@@ -2650,6 +4783,26 @@
           "normalized": "integration",
           "display": "Integration",
           "kind": "alias"
+        },
+        {
+          "normalized": "zheng he ",
+          "display": "整合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhenghe",
+          "display": "整合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "整合",
+          "display": "整合",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zh",
+          "display": "zh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zhi",
@@ -2683,6 +4836,7 @@
       "title": "内部沟通（Internal Communication）",
       "aliases": [
         "Internal Communication",
+        "内部沟通",
         "内部沟通（Internal Communication）"
       ],
       "tokens": [
@@ -2695,6 +4849,26 @@
           "normalized": "internalcommunication",
           "display": "Internal Communication",
           "kind": "alias"
+        },
+        {
+          "normalized": "nei bu gou tong ",
+          "display": "内部沟通",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neibugoutong",
+          "display": "内部沟通",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部沟通",
+          "display": "内部沟通",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nbgt",
+          "display": "nbgt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "nbgtic",
@@ -2733,7 +4907,11 @@
       "title": "内部自助者（Internal Self Helper，ISH）",
       "aliases": [
         "ISH",
+        "ISH）",
         "Internal Self Helper",
+        "Internal Self Helper，ISH",
+        "内部自助者",
+        "内部自助者（Internal Self Helper",
         "内部自助者（Internal Self Helper，ISH）"
       ],
       "tokens": [
@@ -2743,8 +4921,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "internal self helper,ish",
+          "display": "Internal Self Helper，ISH",
+          "kind": "alias"
+        },
+        {
+          "normalized": "internal self helper，ish",
+          "display": "Internal Self Helper，ISH",
+          "kind": "alias"
+        },
+        {
           "normalized": "internalselfhelper",
           "display": "Internal Self Helper",
+          "kind": "alias"
+        },
+        {
+          "normalized": "internalselfhelper,ish",
+          "display": "Internal Self Helper，ISH",
+          "kind": "alias"
+        },
+        {
+          "normalized": "internalselfhelper，ish",
+          "display": "Internal Self Helper，ISH",
           "kind": "alias"
         },
         {
@@ -2753,9 +4951,69 @@
           "kind": "alias"
         },
         {
+          "normalized": "ish)",
+          "display": "ISH）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ish）",
+          "display": "ISH）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei bu zi zhu zhe ",
+          "display": "内部自助者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei bu zi zhu zhe (internal self helper",
+          "display": "内部自助者（Internal Self Helper",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neibuzizhuzhe",
+          "display": "内部自助者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neibuzizhuzhe(internalselfhelper",
+          "display": "内部自助者（Internal Self Helper",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部自助者",
+          "display": "内部自助者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部自助者（internal self helper",
+          "display": "内部自助者（Internal Self Helper",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内部自助者（internalselfhelper",
+          "display": "内部自助者（Internal Self Helper",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nbzzz",
+          "display": "nbzzz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "nbzzzish",
+          "display": "nbzzzish",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "nbzzzishi",
           "display": "nbzzzishi",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "neibuzizhuzheinternalselfhelper",
+          "display": "neibuzizhuzheinternalselfhelper",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "neibuzizhuzheinternalselfhelperish",
@@ -2789,6 +5047,7 @@
       "title": "侵入性思维（Intrusive Thoughts）",
       "aliases": [
         "Intrusive Thoughts",
+        "侵入性思维",
         "侵入性思维（Intrusive Thoughts）"
       ],
       "tokens": [
@@ -2801,6 +5060,26 @@
           "normalized": "intrusivethoughts",
           "display": "Intrusive Thoughts",
           "kind": "alias"
+        },
+        {
+          "normalized": "qin ru xing si wei ",
+          "display": "侵入性思维",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qinruxingsiwei",
+          "display": "侵入性思维",
+          "kind": "alias"
+        },
+        {
+          "normalized": "侵入性思维",
+          "display": "侵入性思维",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qrxsw",
+          "display": "qrxsw",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qrxswit",
@@ -2839,13 +5118,34 @@
       "title": "迭代（Iteration）",
       "aliases": [
         "Iteration",
+        "迭代",
         "迭代（Iteration）"
       ],
       "tokens": [
         {
+          "normalized": "die dai ",
+          "display": "迭代",
+          "kind": "alias"
+        },
+        {
+          "normalized": "diedai",
+          "display": "迭代",
+          "kind": "alias"
+        },
+        {
           "normalized": "iteration",
           "display": "Iteration",
           "kind": "alias"
+        },
+        {
+          "normalized": "迭代",
+          "display": "迭代",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dd",
+          "display": "dd",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "ddi",
@@ -2879,6 +5179,7 @@
       "title": "卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）",
       "aliases": [
         "Kafka Metamorphosis Identity Dissolution",
+        "卡夫卡《变形记》与异化的身份解体",
         "卡夫卡《变形记》与异化的身份解体（Kafka Metamorphosis Identity Dissolution）"
       ],
       "tokens": [
@@ -2893,9 +5194,34 @@
           "kind": "alias"
         },
         {
+          "normalized": "qia fu qia <<bian xing ji >> yu yi hua de shen fen jie ti ",
+          "display": "卡夫卡《变形记》与异化的身份解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiafuqia<<bianxingji>>yuyihuadeshenfenjieti",
+          "display": "卡夫卡《变形记》与异化的身份解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "卡夫卡《变形记》与异化的身份解体",
+          "display": "卡夫卡《变形记》与异化的身份解体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qfqbxjyyhdsfjt",
+          "display": "qfqbxjyyhdsfjt",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "qfqbxjyyhdsfjtkmid",
           "display": "qfqbxjyyhdsfjtkmid",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qiafuqiabianxingjiyuyihuadeshenfenjieti",
+          "display": "qiafuqiabianxingjiyuyihuadeshenfenjieti",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "qiafuqiabianxingjiyuyihuadeshenfenjietikafkametamorphosisidentitydissolution",
@@ -2929,6 +5255,7 @@
       "title": "习得性无助（Learned Helplessness）",
       "aliases": [
         "Learned Helplessness",
+        "习得性无助",
         "习得性无助（Learned Helplessness）"
       ],
       "tokens": [
@@ -2941,6 +5268,26 @@
           "normalized": "learnedhelplessness",
           "display": "Learned Helplessness",
           "kind": "alias"
+        },
+        {
+          "normalized": "xi de xing wu zhu ",
+          "display": "习得性无助",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xidexingwuzhu",
+          "display": "习得性无助",
+          "kind": "alias"
+        },
+        {
+          "normalized": "习得性无助",
+          "display": "习得性无助",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xdxwz",
+          "display": "xdxwz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "xdxwzlh",
@@ -2979,7 +5326,11 @@
       "title": "小孩意识体（Little / Child Part）",
       "aliases": [
         "Child Part",
+        "Child Part）",
         "Little",
+        "Little / Child Part",
+        "小孩意识体",
+        "小孩意识体（Little",
         "小孩意识体（Little / Child Part）"
       ],
       "tokens": [
@@ -2989,8 +5340,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "child part)",
+          "display": "Child Part）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "child part）",
+          "display": "Child Part）",
+          "kind": "alias"
+        },
+        {
           "normalized": "childpart",
           "display": "Child Part",
+          "kind": "alias"
+        },
+        {
+          "normalized": "childpart)",
+          "display": "Child Part）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "childpart）",
+          "display": "Child Part）",
           "kind": "alias"
         },
         {
@@ -2999,9 +5370,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "little / child part",
+          "display": "Little / Child Part",
+          "kind": "alias"
+        },
+        {
+          "normalized": "littlechildpart",
+          "display": "Little / Child Part",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xiao hai yi shi ti ",
+          "display": "小孩意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xiao hai yi shi ti (little",
+          "display": "小孩意识体（Little",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xiaohaiyishiti",
+          "display": "小孩意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xiaohaiyishiti(little",
+          "display": "小孩意识体（Little",
+          "kind": "alias"
+        },
+        {
+          "normalized": "小孩意识体",
+          "display": "小孩意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "小孩意识体（little",
+          "display": "小孩意识体（Little",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xhyst",
+          "display": "xhyst",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xhystl",
+          "display": "xhystl",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "xhystlcp",
           "display": "xhystlcp",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xiaohaiyishitilittle",
+          "display": "xiaohaiyishitilittle",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "xiaohaiyishitilittlechildpart",
@@ -3035,6 +5461,7 @@
       "title": "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）",
       "aliases": [
         "Lovecraft Tulpa Motifs",
+        "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射",
         "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射（Lovecraft Tulpa Motifs）"
       ],
       "tokens": [
@@ -3049,9 +5476,39 @@
           "kind": "alias"
         },
         {
+          "normalized": "luo fu ke la fu te zuo pin zhong de \"xin ling zao wu \"yu  tulpa ying she ",
+          "display": "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "luofukelafutezuopinzhongde\"xinlingzaowu\"yutulpayingshe",
+          "display": "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "洛夫克拉夫特作品中的“心灵造物”与 tulpa 影射",
+          "display": "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "洛夫克拉夫特作品中的“心灵造物”与tulpa影射",
+          "display": "洛夫克拉夫特作品中的“心灵造物”与 Tulpa 影射",
+          "kind": "alias"
+        },
+        {
+          "normalized": "lfklftzpzdxlzwytys",
+          "display": "lfklftzpzdxlzwytys",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "lfklftzpzdxlzwytysltm",
           "display": "lfklftzpzdxlzwytysltm",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "luofukelafutezuopinzhongdexinlingzaowuyutulpayingshe",
+          "display": "luofukelafutezuopinzhongdexinlingzaowuyutulpayingshe",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "luofukelafutezuopinzhongdexinlingzaowuyutulpayingshelovecrafttulpamotifs",
@@ -3085,9 +5542,20 @@
       "title": "《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）",
       "aliases": [
         "Madoka Magica Kyubey Otherness",
+        "《魔法少女小圆》中的丘比与契约式“他者”",
         "《魔法少女小圆》中的丘比与契约式“他者”（Madoka Magica Kyubey Otherness）"
       ],
       "tokens": [
+        {
+          "normalized": "<<mo fa shao nu xiao yuan >> zhong de qiu bi yu qi yue shi \"ta zhe \"",
+          "display": "《魔法少女小圆》中的丘比与契约式“他者”",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<mofashaonuxiaoyuan>>zhongdeqiubiyuqiyueshi\"tazhe\"",
+          "display": "《魔法少女小圆》中的丘比与契约式“他者”",
+          "kind": "alias"
+        },
         {
           "normalized": "madoka magica kyubey otherness",
           "display": "Madoka Magica Kyubey Otherness",
@@ -3099,9 +5567,24 @@
           "kind": "alias"
         },
         {
+          "normalized": "《魔法少女小圆》中的丘比与契约式“他者”",
+          "display": "《魔法少女小圆》中的丘比与契约式“他者”",
+          "kind": "alias"
+        },
+        {
+          "normalized": "mfsnxyzdqbyqystz",
+          "display": "mfsnxyzdqbyqystz",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "mfsnxyzdqbyqystzmmko",
           "display": "mfsnxyzdqbyqystzmmko",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "mofashaonuxiaoyuanzhongdeqiubiyuqiyueshitazhe",
+          "display": "mofashaonuxiaoyuanzhongdeqiubiyuqiyueshitazhe",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "mofashaonuxiaoyuanzhongdeqiubiyuqiyueshitazhemadokamagicakyubeyotherness",
@@ -3135,6 +5618,7 @@
       "title": "主体（Main）",
       "aliases": [
         "Main",
+        "主体",
         "主体（Main）"
       ],
       "tokens": [
@@ -3142,6 +5626,26 @@
           "normalized": "main",
           "display": "Main",
           "kind": "alias"
+        },
+        {
+          "normalized": "zhu ti ",
+          "display": "主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhuti",
+          "display": "主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "主体",
+          "display": "主体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zt",
+          "display": "zt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "ztm",
@@ -3175,6 +5679,7 @@
       "title": "躁狂（Mania）",
       "aliases": [
         "Mania",
+        "躁狂",
         "躁狂（Mania）"
       ],
       "tokens": [
@@ -3182,6 +5687,26 @@
           "normalized": "mania",
           "display": "Mania",
           "kind": "alias"
+        },
+        {
+          "normalized": "zao kuang ",
+          "display": "躁狂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zaokuang",
+          "display": "躁狂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "躁狂",
+          "display": "躁狂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zk",
+          "display": "zk",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zkm",
@@ -3215,6 +5740,7 @@
       "title": "冥想（Meditation）",
       "aliases": [
         "Meditation",
+        "冥想",
         "冥想（Meditation）"
       ],
       "tokens": [
@@ -3222,6 +5748,26 @@
           "normalized": "meditation",
           "display": "Meditation",
           "kind": "alias"
+        },
+        {
+          "normalized": "ming xiang ",
+          "display": "冥想",
+          "kind": "alias"
+        },
+        {
+          "normalized": "mingxiang",
+          "display": "冥想",
+          "kind": "alias"
+        },
+        {
+          "normalized": "冥想",
+          "display": "冥想",
+          "kind": "alias"
+        },
+        {
+          "normalized": "mx",
+          "display": "mx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "mxm",
@@ -3255,9 +5801,20 @@
       "title": "记忆持有者（Memory Holder）",
       "aliases": [
         "Memory Holder",
+        "记忆持有者",
         "记忆持有者（Memory Holder）"
       ],
       "tokens": [
+        {
+          "normalized": "ji yi chi you zhe ",
+          "display": "记忆持有者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiyichiyouzhe",
+          "display": "记忆持有者",
+          "kind": "alias"
+        },
         {
           "normalized": "memory holder",
           "display": "Memory Holder",
@@ -3267,6 +5824,16 @@
           "normalized": "memoryholder",
           "display": "Memory Holder",
           "kind": "alias"
+        },
+        {
+          "normalized": "记忆持有者",
+          "display": "记忆持有者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jycyz",
+          "display": "jycyz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jycyzmh",
@@ -3305,9 +5872,20 @@
       "title": "记忆屏蔽（Memory Shielding）",
       "aliases": [
         "Memory Shielding",
+        "记忆屏蔽",
         "记忆屏蔽（Memory Shielding）"
       ],
       "tokens": [
+        {
+          "normalized": "ji yi ping bi ",
+          "display": "记忆屏蔽",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiyipingbi",
+          "display": "记忆屏蔽",
+          "kind": "alias"
+        },
         {
           "normalized": "memory shielding",
           "display": "Memory Shielding",
@@ -3317,6 +5895,16 @@
           "normalized": "memoryshielding",
           "display": "Memory Shielding",
           "kind": "alias"
+        },
+        {
+          "normalized": "记忆屏蔽",
+          "display": "记忆屏蔽",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jypb",
+          "display": "jypb",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jypbms",
@@ -3355,13 +5943,42 @@
       "title": "混合型系统（Mixed Systems, Xianyu Theory）",
       "aliases": [
         "Mixed Systems",
+        "Mixed Systems, Xianyu Theory",
         "Xianyu Theory",
+        "Xianyu Theory）",
+        "混合型系统",
+        "混合型系统（Mixed Systems",
         "混合型系统（Mixed Systems, Xianyu Theory）"
       ],
       "tokens": [
         {
+          "normalized": "hun he xing xi tong ",
+          "display": "混合型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hun he xing xi tong (mixed systems",
+          "display": "混合型系统（Mixed Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hunhexingxitong",
+          "display": "混合型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hunhexingxitong(mixedsystems",
+          "display": "混合型系统（Mixed Systems",
+          "kind": "alias"
+        },
+        {
           "normalized": "mixed systems",
           "display": "Mixed Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "mixed systems, xianyu theory",
+          "display": "Mixed Systems, Xianyu Theory",
           "kind": "alias"
         },
         {
@@ -3370,8 +5987,23 @@
           "kind": "alias"
         },
         {
+          "normalized": "mixedsystems,xianyutheory",
+          "display": "Mixed Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
           "normalized": "xianyu theory",
           "display": "Xianyu Theory",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory）",
+          "display": "Xianyu Theory）",
           "kind": "alias"
         },
         {
@@ -3380,9 +6012,49 @@
           "kind": "alias"
         },
         {
+          "normalized": "xianyutheory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyutheory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "混合型系统",
+          "display": "混合型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "混合型系统（mixed systems",
+          "display": "混合型系统（Mixed Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "混合型系统（mixedsystems",
+          "display": "混合型系统（Mixed Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hhxxt",
+          "display": "hhxxt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hhxxtms",
+          "display": "hhxxtms",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "hhxxtmsxt",
           "display": "hhxxtmsxt",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hunhexingxitongmixedsystems",
+          "display": "hunhexingxitongmixedsystems",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "hunhexingxitongmixedsystemsxianyutheory",
@@ -3416,9 +6088,20 @@
       "title": "《隐形人》（Mr. Robot）中的人格分裂叙事",
       "aliases": [
         "Mr. Robot",
+        "《隐形人》 中的人格分裂叙事",
         "《隐形人》（Mr. Robot）中的人格分裂叙事"
       ],
       "tokens": [
+        {
+          "normalized": "<<yin xing ren >>  zhong de ren ge fen lie xu shi ",
+          "display": "《隐形人》 中的人格分裂叙事",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<yinxingren>>zhongderengefenliexushi",
+          "display": "《隐形人》 中的人格分裂叙事",
+          "kind": "alias"
+        },
         {
           "normalized": "mr. robot",
           "display": "Mr. Robot",
@@ -3430,13 +6113,33 @@
           "kind": "alias"
         },
         {
+          "normalized": "《隐形人》 中的人格分裂叙事",
+          "display": "《隐形人》 中的人格分裂叙事",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《隐形人》中的人格分裂叙事",
+          "display": "《隐形人》 中的人格分裂叙事",
+          "kind": "alias"
+        },
+        {
           "normalized": "yxrmrzdrgflxs",
           "display": "yxrmrzdrgflxs",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "yxrzdrgflxs",
+          "display": "yxrzdrgflxs",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "yinxingrenmrrobotzhongderengefenliexushi",
           "display": "yinxingrenmrrobotzhongderengefenliexushi",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "yinxingrenzhongderengefenliexushi",
+          "display": "yinxingrenzhongderengefenliexushi",
           "kind": "pinyin_full"
         },
         {
@@ -3466,7 +6169,11 @@
       "title": "自恋型人格障碍（Narcissistic Personality Disorder，NPD）",
       "aliases": [
         "NPD",
+        "NPD）",
         "Narcissistic Personality Disorder",
+        "Narcissistic Personality Disorder，NPD",
+        "自恋型人格障碍",
+        "自恋型人格障碍（Narcissistic Personality Disorder",
         "自恋型人格障碍（Narcissistic Personality Disorder，NPD）"
       ],
       "tokens": [
@@ -3476,8 +6183,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "narcissistic personality disorder,npd",
+          "display": "Narcissistic Personality Disorder，NPD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "narcissistic personality disorder，npd",
+          "display": "Narcissistic Personality Disorder，NPD",
+          "kind": "alias"
+        },
+        {
           "normalized": "narcissisticpersonalitydisorder",
           "display": "Narcissistic Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "narcissisticpersonalitydisorder,npd",
+          "display": "Narcissistic Personality Disorder，NPD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "narcissisticpersonalitydisorder，npd",
+          "display": "Narcissistic Personality Disorder，NPD",
           "kind": "alias"
         },
         {
@@ -3486,9 +6213,69 @@
           "kind": "alias"
         },
         {
+          "normalized": "npd)",
+          "display": "NPD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "npd）",
+          "display": "NPD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zi lian xing ren ge zhang ai ",
+          "display": "自恋型人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zi lian xing ren ge zhang ai (narcissistic personality disorder",
+          "display": "自恋型人格障碍（Narcissistic Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zilianxingrengezhangai",
+          "display": "自恋型人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zilianxingrengezhangai(narcissisticpersonalitydisorder",
+          "display": "自恋型人格障碍（Narcissistic Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "自恋型人格障碍",
+          "display": "自恋型人格障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "自恋型人格障碍（narcissistic personality disorder",
+          "display": "自恋型人格障碍（Narcissistic Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "自恋型人格障碍（narcissisticpersonalitydisorder",
+          "display": "自恋型人格障碍（Narcissistic Personality Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zlxrgza",
+          "display": "zlxrgza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zlxrgzanpd",
+          "display": "zlxrgzanpd",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "zlxrgzanpdn",
           "display": "zlxrgzanpdn",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zilianxingrengezhangainarcissisticpersonalitydisorder",
+          "display": "zilianxingrengezhangainarcissisticpersonalitydisorder",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "zilianxingrengezhangainarcissisticpersonalitydisordernpd",
@@ -3522,6 +6309,7 @@
       "title": "神经多样性（Neurodiversity）",
       "aliases": [
         "Neurodiversity",
+        "神经多样性",
         "神经多样性（Neurodiversity）"
       ],
       "tokens": [
@@ -3529,6 +6317,26 @@
           "normalized": "neurodiversity",
           "display": "Neurodiversity",
           "kind": "alias"
+        },
+        {
+          "normalized": "shen jing duo yang xing ",
+          "display": "神经多样性",
+          "kind": "alias"
+        },
+        {
+          "normalized": "shenjingduoyangxing",
+          "display": "神经多样性",
+          "kind": "alias"
+        },
+        {
+          "normalized": "神经多样性",
+          "display": "神经多样性",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sjdyx",
+          "display": "sjdyx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "sjdyxn",
@@ -3562,13 +6370,118 @@
       "title": "《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）",
       "aliases": [
         "Lilith",
-        "《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）"
+        "《不",
+        "《不/存在的你，和我》与 Tulpa —— 莉莉丝",
+        "《不/存在的你，和我》与 Tulpa —— 莉莉丝（Lilith）",
+        "和我》与 Tulpa —— 莉莉丝",
+        "和我》与 Tulpa —— 莉莉丝（Lilith）",
+        "存在的你"
       ],
       "tokens": [
+        {
+          "normalized": "<<bu",
+          "display": "《不",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bu ",
+          "display": "《不",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bu /cun zai de ni ,he wo >> yu  tulpa ---- li li si ",
+          "display": "《不/存在的你，和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<bucunzaideni,hewo>>yutulpalilisi",
+          "display": "《不/存在的你，和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cun zai de ni ",
+          "display": "存在的你",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cunzaideni",
+          "display": "存在的你",
+          "kind": "alias"
+        },
+        {
+          "normalized": "he wo >> yu  tulpa ---- li li si ",
+          "display": "和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "he wo >> yu  tulpa ---- li li si (lilith)",
+          "display": "和我》与 Tulpa —— 莉莉丝（Lilith）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hewo>>yutulpalilisi",
+          "display": "和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hewo>>yutulpalilisi(lilith)",
+          "display": "和我》与 Tulpa —— 莉莉丝（Lilith）",
+          "kind": "alias"
+        },
         {
           "normalized": "lilith",
           "display": "Lilith",
           "kind": "alias"
+        },
+        {
+          "normalized": "《不",
+          "display": "《不",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《不/存在的你，和我》与 tulpa —— 莉莉丝",
+          "display": "《不/存在的你，和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《不存在的你，和我》与tulpa——莉莉丝",
+          "display": "《不/存在的你，和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "和我》与 tulpa —— 莉莉丝",
+          "display": "和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "和我》与 tulpa —— 莉莉丝（lilith）",
+          "display": "和我》与 Tulpa —— 莉莉丝（Lilith）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "和我》与tulpa——莉莉丝",
+          "display": "和我》与 Tulpa —— 莉莉丝",
+          "kind": "alias"
+        },
+        {
+          "normalized": "和我》与tulpa——莉莉丝（lilith）",
+          "display": "和我》与 Tulpa —— 莉莉丝（Lilith）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "存在的你",
+          "display": "存在的你",
+          "kind": "alias"
+        },
+        {
+          "normalized": "b",
+          "display": "b",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bczdnhwytlls",
+          "display": "bczdnhwytlls",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "bczdnhwytllsl",
@@ -3576,8 +6489,43 @@
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "czdn",
+          "display": "czdn",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hwytlls",
+          "display": "hwytlls",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "hwytllsl",
+          "display": "hwytllsl",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bu",
+          "display": "bu",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "bucunzaidenihewoyutulpalilisi",
+          "display": "bucunzaidenihewoyutulpalilisi",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "bucunzaidenihewoyutulpalilisililith",
           "display": "bucunzaidenihewoyutulpalilisililith",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "hewoyutulpalilisi",
+          "display": "hewoyutulpalilisi",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "hewoyutulpalilisililith",
+          "display": "hewoyutulpalilisililith",
           "kind": "pinyin_full"
         },
         {
@@ -3607,7 +6555,11 @@
       "title": "强迫症（Obsessive-Compulsive Disorder, OCD）",
       "aliases": [
         "OCD",
+        "OCD）",
         "Obsessive-Compulsive Disorder",
+        "Obsessive-Compulsive Disorder, OCD",
+        "强迫症",
+        "强迫症（Obsessive-Compulsive Disorder",
         "强迫症（Obsessive-Compulsive Disorder, OCD）"
       ],
       "tokens": [
@@ -3617,8 +6569,18 @@
           "kind": "alias"
         },
         {
+          "normalized": "obsessive-compulsive disorder, ocd",
+          "display": "Obsessive-Compulsive Disorder, OCD",
+          "kind": "alias"
+        },
+        {
           "normalized": "obsessivecompulsivedisorder",
           "display": "Obsessive-Compulsive Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "obsessivecompulsivedisorder,ocd",
+          "display": "Obsessive-Compulsive Disorder, OCD",
           "kind": "alias"
         },
         {
@@ -3627,9 +6589,69 @@
           "kind": "alias"
         },
         {
+          "normalized": "ocd)",
+          "display": "OCD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ocd）",
+          "display": "OCD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiang po zheng ",
+          "display": "强迫症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiang po zheng (obsessive-compulsive disorder",
+          "display": "强迫症（Obsessive-Compulsive Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiangpozheng",
+          "display": "强迫症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiangpozheng(obsessivecompulsivedisorder",
+          "display": "强迫症（Obsessive-Compulsive Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "强迫症",
+          "display": "强迫症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "强迫症（obsessive-compulsive disorder",
+          "display": "强迫症（Obsessive-Compulsive Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "强迫症（obsessivecompulsivedisorder",
+          "display": "强迫症（Obsessive-Compulsive Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qpz",
+          "display": "qpz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qpzocd",
+          "display": "qpzocd",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "qpzocdo",
           "display": "qpzocdo",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qiangpozhengobsessivecompulsivedisorder",
+          "display": "qiangpozhengobsessivecompulsivedisorder",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "qiangpozhengobsessivecompulsivedisorderocd",
@@ -3659,50 +6681,11 @@
       ]
     },
     {
-      "path": "entries/Original.md",
-      "title": "初始（Original）",
-      "aliases": [
-        "Original",
-        "初始（Original）"
-      ],
-      "tokens": [
-        {
-          "normalized": "original",
-          "display": "Original",
-          "kind": "alias"
-        },
-        {
-          "normalized": "cso",
-          "display": "cso",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "chushioriginal",
-          "display": "chushioriginal",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "chu shi (original)",
-          "display": "初始（Original）",
-          "kind": "title"
-        },
-        {
-          "normalized": "chushi(original)",
-          "display": "初始（Original）",
-          "kind": "title"
-        },
-        {
-          "normalized": "初始（original）",
-          "display": "初始（Original）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
       "path": "entries/OSDD.md",
       "title": "其他特定解离性障碍（OSDD）",
       "aliases": [
         "OSDD",
+        "其他特定解离性障碍",
         "其他特定解离性障碍（OSDD）"
       ],
       "tokens": [
@@ -3710,6 +6693,26 @@
           "normalized": "osdd",
           "display": "OSDD",
           "kind": "alias"
+        },
+        {
+          "normalized": "qi ta te ding jie chi xing zhang ai ",
+          "display": "其他特定解离性障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qitatedingjiechixingzhangai",
+          "display": "其他特定解离性障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "其他特定解离性障碍",
+          "display": "其他特定解离性障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qttdjcxza",
+          "display": "qttdjcxza",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qttdjcxzao",
@@ -3739,13 +6742,258 @@
       ]
     },
     {
+      "path": "entries/Original.md",
+      "title": "初始（Original）",
+      "aliases": [
+        "Original",
+        "初始",
+        "初始（Original）"
+      ],
+      "tokens": [
+        {
+          "normalized": "chu shi ",
+          "display": "初始",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chushi",
+          "display": "初始",
+          "kind": "alias"
+        },
+        {
+          "normalized": "original",
+          "display": "Original",
+          "kind": "alias"
+        },
+        {
+          "normalized": "初始",
+          "display": "初始",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cs",
+          "display": "cs",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "cso",
+          "display": "cso",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "chushioriginal",
+          "display": "chushioriginal",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "chu shi (original)",
+          "display": "初始（Original）",
+          "kind": "title"
+        },
+        {
+          "normalized": "chushi(original)",
+          "display": "初始（Original）",
+          "kind": "title"
+        },
+        {
+          "normalized": "初始（original）",
+          "display": "初始（Original）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
+      "path": "entries/PTSD.md",
+      "title": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
+      "aliases": [
+        "PTSD",
+        "PTSD）",
+        "Post-Traumatic Stress Disorder",
+        "Post-Traumatic Stress Disorder, PTSD",
+        "chuangshanghouyingjizhangai",
+        "创伤后压力症候群",
+        "创伤后应激反应障碍",
+        "创伤后应激障碍",
+        "创伤后应激障碍（Post-Traumatic Stress Disorder",
+        "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）"
+      ],
+      "tokens": [
+        {
+          "normalized": "chuang shang hou ying ji zhang ai ",
+          "display": "创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chuang shang hou ying ji zhang ai (post-traumatic stress disorder",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chuangshanghouyingjizhangai",
+          "display": "创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chuangshanghouyingjizhangai(posttraumaticstressdisorder",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "post-traumatic stress disorder",
+          "display": "Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "post-traumatic stress disorder, ptsd",
+          "display": "Post-Traumatic Stress Disorder, PTSD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "posttraumaticstressdisorder",
+          "display": "Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "posttraumaticstressdisorder,ptsd",
+          "display": "Post-Traumatic Stress Disorder, PTSD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ptsd",
+          "display": "PTSD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ptsd)",
+          "display": "PTSD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ptsd）",
+          "display": "PTSD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "创伤后应激障碍",
+          "display": "创伤后应激障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "创伤后应激障碍（post-traumatic stress disorder",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "创伤后应激障碍（posttraumaticstressdisorder",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cshyjfyza",
+          "display": "cshyjfyza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "cshyjza",
+          "display": "cshyjza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "cshyjzaptsd",
+          "display": "cshyjzaptsd",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "cshyjzaptsdp",
+          "display": "cshyjzaptsdp",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "cshylzhq",
+          "display": "cshylzhq",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "chuangshanghouyingjizhangaiposttraumaticstressdisorder",
+          "display": "chuangshanghouyingjizhangaiposttraumaticstressdisorder",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "chuangshanghouyingjizhangaiposttraumaticstressdisorderptsd",
+          "display": "chuangshanghouyingjizhangaiposttraumaticstressdisorderptsd",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "chuang shang hou ya li zheng hou qun ",
+          "display": "创伤后压力症候群",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "chuang shang hou ying ji fan ying zhang ai ",
+          "display": "创伤后应激反应障碍",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "chuangshanghouyalizhenghouqun",
+          "display": "创伤后压力症候群",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "chuangshanghouyingjifanyingzhangai",
+          "display": "创伤后应激反应障碍",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "创伤后压力症候群",
+          "display": "创伤后压力症候群",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "创伤后应激反应障碍",
+          "display": "创伤后应激反应障碍",
+          "kind": "synonym"
+        },
+        {
+          "normalized": "chuang shang hou ying ji zhang ai (post-traumatic stress disorder, ptsd)",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
+          "kind": "title"
+        },
+        {
+          "normalized": "chuangshanghouyingjizhangai(posttraumaticstressdisorder,ptsd)",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
+          "kind": "title"
+        },
+        {
+          "normalized": "创伤后应激障碍（post-traumatic stress disorder, ptsd）",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
+          "kind": "title"
+        },
+        {
+          "normalized": "创伤后应激障碍（posttraumaticstressdisorder,ptsd）",
+          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
+          "kind": "title"
+        }
+      ]
+    },
+    {
       "path": "entries/Paranoia-Agent-Collective-Consciousness.md",
       "title": "《妄想代理人》（Paranoia Agent）与集体意识的具象化",
       "aliases": [
         "Paranoia Agent",
+        "《妄想代理人》 与集体意识的具象化",
         "《妄想代理人》（Paranoia Agent）与集体意识的具象化"
       ],
       "tokens": [
+        {
+          "normalized": "<<wang xiang dai li ren >>  yu ji ti yi shi de ju xiang hua ",
+          "display": "《妄想代理人》 与集体意识的具象化",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<wangxiangdailiren>>yujitiyishidejuxianghua",
+          "display": "《妄想代理人》 与集体意识的具象化",
+          "kind": "alias"
+        },
         {
           "normalized": "paranoia agent",
           "display": "Paranoia Agent",
@@ -3757,13 +7005,33 @@
           "kind": "alias"
         },
         {
+          "normalized": "《妄想代理人》 与集体意识的具象化",
+          "display": "《妄想代理人》 与集体意识的具象化",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《妄想代理人》与集体意识的具象化",
+          "display": "《妄想代理人》 与集体意识的具象化",
+          "kind": "alias"
+        },
+        {
           "normalized": "wxdlrpayjtysdjxh",
           "display": "wxdlrpayjtysdjxh",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "wxdlryjtysdjxh",
+          "display": "wxdlryjtysdjxh",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "wangxiangdailirenparanoiaagentyujitiyishidejuxianghua",
           "display": "wangxiangdailirenparanoiaagentyujitiyishidejuxianghua",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "wangxiangdailirenyujitiyishidejuxianghua",
+          "display": "wangxiangdailirenyujitiyishidejuxianghua",
           "kind": "pinyin_full"
         },
         {
@@ -3793,13 +7061,47 @@
       "title": "部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）",
       "aliases": [
         "PDID",
+        "PDID）",
         "Partial Dissociative Identity Disorder",
+        "Partial Dissociative Identity Disorder，PDID",
+        "部分解离性身份障碍",
+        "部分解离性身份障碍（Partial Dissociative Identity Disorder",
         "部分解离性身份障碍（Partial Dissociative Identity Disorder，PDID）"
       ],
       "tokens": [
         {
+          "normalized": "bu fen jie chi xing shen fen zhang ai ",
+          "display": "部分解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bu fen jie chi xing shen fen zhang ai (partial dissociative identity disorder",
+          "display": "部分解离性身份障碍（Partial Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bufenjiechixingshenfenzhangai",
+          "display": "部分解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bufenjiechixingshenfenzhangai(partialdissociativeidentitydisorder",
+          "display": "部分解离性身份障碍（Partial Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
           "normalized": "partial dissociative identity disorder",
           "display": "Partial Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "partial dissociative identity disorder,pdid",
+          "display": "Partial Dissociative Identity Disorder，PDID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "partial dissociative identity disorder，pdid",
+          "display": "Partial Dissociative Identity Disorder，PDID",
           "kind": "alias"
         },
         {
@@ -3808,14 +7110,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "partialdissociativeidentitydisorder,pdid",
+          "display": "Partial Dissociative Identity Disorder，PDID",
+          "kind": "alias"
+        },
+        {
+          "normalized": "partialdissociativeidentitydisorder，pdid",
+          "display": "Partial Dissociative Identity Disorder，PDID",
+          "kind": "alias"
+        },
+        {
           "normalized": "pdid",
           "display": "PDID",
           "kind": "alias"
         },
         {
+          "normalized": "pdid)",
+          "display": "PDID）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pdid）",
+          "display": "PDID）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "部分解离性身份障碍",
+          "display": "部分解离性身份障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "部分解离性身份障碍（partial dissociative identity disorder",
+          "display": "部分解离性身份障碍（Partial Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "部分解离性身份障碍（partialdissociativeidentitydisorder",
+          "display": "部分解离性身份障碍（Partial Dissociative Identity Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bfjcxsfza",
+          "display": "bfjcxsfza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bfjcxsfzapdid",
+          "display": "bfjcxsfzapdid",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "bfjcxsfzapdidp",
           "display": "bfjcxsfzapdidp",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "bufenjiechixingshenfenzhangaipartialdissociativeidentitydisorder",
+          "display": "bufenjiechixingshenfenzhangaipartialdissociativeidentitydisorder",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "bufenjiechixingshenfenzhangaipartialdissociativeidentitydisorderpdid",
@@ -3849,9 +7201,20 @@
       "title": "病理性解离（Pathological Dissociation）",
       "aliases": [
         "Pathological Dissociation",
+        "病理性解离",
         "病理性解离（Pathological Dissociation）"
       ],
       "tokens": [
+        {
+          "normalized": "bing li xing jie chi ",
+          "display": "病理性解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "binglixingjiechi",
+          "display": "病理性解离",
+          "kind": "alias"
+        },
         {
           "normalized": "pathological dissociation",
           "display": "Pathological Dissociation",
@@ -3861,6 +7224,16 @@
           "normalized": "pathologicaldissociation",
           "display": "Pathological Dissociation",
           "kind": "alias"
+        },
+        {
+          "normalized": "病理性解离",
+          "display": "病理性解离",
+          "kind": "alias"
+        },
+        {
+          "normalized": "blxjc",
+          "display": "blxjc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "blxjcpd",
@@ -3899,7 +7272,11 @@
       "title": "执行者（Performer / Executive）",
       "aliases": [
         "Executive",
+        "Executive）",
         "Performer",
+        "Performer / Executive",
+        "执行者",
+        "执行者（Performer",
         "执行者（Performer / Executive）"
       ],
       "tokens": [
@@ -3909,14 +7286,79 @@
           "kind": "alias"
         },
         {
+          "normalized": "executive)",
+          "display": "Executive）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "executive）",
+          "display": "Executive）",
+          "kind": "alias"
+        },
+        {
           "normalized": "performer",
           "display": "Performer",
           "kind": "alias"
         },
         {
+          "normalized": "performer / executive",
+          "display": "Performer / Executive",
+          "kind": "alias"
+        },
+        {
+          "normalized": "performerexecutive",
+          "display": "Performer / Executive",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhi xing zhe ",
+          "display": "执行者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhi xing zhe (performer",
+          "display": "执行者（Performer",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhixingzhe",
+          "display": "执行者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhixingzhe(performer",
+          "display": "执行者（Performer",
+          "kind": "alias"
+        },
+        {
+          "normalized": "执行者",
+          "display": "执行者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "执行者（performer",
+          "display": "执行者（Performer",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zxz",
+          "display": "zxz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zxzp",
+          "display": "zxzp",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "zxzpe",
           "display": "zxzpe",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zhixingzheperformer",
+          "display": "zhixingzheperformer",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "zhixingzheperformerexecutive",
@@ -3950,6 +7392,7 @@
       "title": "权限（Permissions）",
       "aliases": [
         "Permissions",
+        "权限",
         "权限（Permissions）"
       ],
       "tokens": [
@@ -3957,6 +7400,26 @@
           "normalized": "permissions",
           "display": "Permissions",
           "kind": "alias"
+        },
+        {
+          "normalized": "quan xian ",
+          "display": "权限",
+          "kind": "alias"
+        },
+        {
+          "normalized": "quanxian",
+          "display": "权限",
+          "kind": "alias"
+        },
+        {
+          "normalized": "权限",
+          "display": "权限",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qx",
+          "display": "qx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qxp",
@@ -3990,6 +7453,7 @@
       "title": "迫害者（Persecutor）",
       "aliases": [
         "Persecutor",
+        "迫害者",
         "迫害者（Persecutor）"
       ],
       "tokens": [
@@ -3997,6 +7461,26 @@
           "normalized": "persecutor",
           "display": "Persecutor",
           "kind": "alias"
+        },
+        {
+          "normalized": "po hai zhe ",
+          "display": "迫害者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "pohaizhe",
+          "display": "迫害者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "迫害者",
+          "display": "迫害者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "phz",
+          "display": "phz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "phzp",
@@ -4030,6 +7514,7 @@
       "title": "人格面具（Persona）",
       "aliases": [
         "Persona",
+        "人格面具",
         "人格面具（Persona）"
       ],
       "tokens": [
@@ -4037,6 +7522,26 @@
           "normalized": "persona",
           "display": "Persona",
           "kind": "alias"
+        },
+        {
+          "normalized": "ren ge mian ju ",
+          "display": "人格面具",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rengemianju",
+          "display": "人格面具",
+          "kind": "alias"
+        },
+        {
+          "normalized": "人格面具",
+          "display": "人格面具",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rgmj",
+          "display": "rgmj",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "rgmjp",
@@ -4070,9 +7575,20 @@
       "title": "多重意识体基础（Plurality Basics）",
       "aliases": [
         "Plurality Basics",
+        "多重意识体基础",
         "多重意识体基础（Plurality Basics）"
       ],
       "tokens": [
+        {
+          "normalized": "duo zhong yi shi ti ji chu ",
+          "display": "多重意识体基础",
+          "kind": "alias"
+        },
+        {
+          "normalized": "duozhongyishitijichu",
+          "display": "多重意识体基础",
+          "kind": "alias"
+        },
         {
           "normalized": "plurality basics",
           "display": "Plurality Basics",
@@ -4082,6 +7598,16 @@
           "normalized": "pluralitybasics",
           "display": "Plurality Basics",
           "kind": "alias"
+        },
+        {
+          "normalized": "多重意识体基础",
+          "display": "多重意识体基础",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dzystjc",
+          "display": "dzystjc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "dzystjcpb",
@@ -4120,13 +7646,34 @@
       "title": "多意识体（Plurality）",
       "aliases": [
         "Plurality",
+        "多意识体",
         "多意识体（Plurality）"
       ],
       "tokens": [
         {
+          "normalized": "duo yi shi ti ",
+          "display": "多意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "duoyishiti",
+          "display": "多意识体",
+          "kind": "alias"
+        },
+        {
           "normalized": "plurality",
           "display": "Plurality",
           "kind": "alias"
+        },
+        {
+          "normalized": "多意识体",
+          "display": "多意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dyst",
+          "display": "dyst",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "dystp",
@@ -4160,13 +7707,34 @@
       "title": "超级破碎（Polyfragmented）",
       "aliases": [
         "Polyfragmented",
+        "超级破碎",
         "超级破碎（Polyfragmented）"
       ],
       "tokens": [
         {
+          "normalized": "chao ji po sui ",
+          "display": "超级破碎",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chaojiposui",
+          "display": "超级破碎",
+          "kind": "alias"
+        },
+        {
           "normalized": "polyfragmented",
           "display": "Polyfragmented",
           "kind": "alias"
+        },
+        {
+          "normalized": "超级破碎",
+          "display": "超级破碎",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cjps",
+          "display": "cjps",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "cjpsp",
@@ -4200,6 +7768,7 @@
       "title": "投影（Projection）",
       "aliases": [
         "Projection",
+        "投影",
         "投影（Projection）"
       ],
       "tokens": [
@@ -4207,6 +7776,26 @@
           "normalized": "projection",
           "display": "Projection",
           "kind": "alias"
+        },
+        {
+          "normalized": "tou ying ",
+          "display": "投影",
+          "kind": "alias"
+        },
+        {
+          "normalized": "touying",
+          "display": "投影",
+          "kind": "alias"
+        },
+        {
+          "normalized": "投影",
+          "display": "投影",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ty",
+          "display": "ty",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "typ",
@@ -4240,13 +7829,34 @@
       "title": "保护者（Protector）",
       "aliases": [
         "Protector",
+        "保护者",
         "保护者（Protector）"
       ],
       "tokens": [
         {
+          "normalized": "bao hu zhe ",
+          "display": "保护者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "baohuzhe",
+          "display": "保护者",
+          "kind": "alias"
+        },
+        {
           "normalized": "protector",
           "display": "Protector",
           "kind": "alias"
+        },
+        {
+          "normalized": "保护者",
+          "display": "保护者",
+          "kind": "alias"
+        },
+        {
+          "normalized": "bhz",
+          "display": "bhz",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "bhzp",
@@ -4276,130 +7886,11 @@
       ]
     },
     {
-      "path": "entries/PTSD.md",
-      "title": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
-      "aliases": [
-        "PTSD",
-        "Post-Traumatic Stress Disorder",
-        "chuangshanghouyingjizhangai",
-        "创伤后压力症候群",
-        "创伤后应激反应障碍",
-        "创伤后应激障碍",
-        "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）"
-      ],
-      "tokens": [
-        {
-          "normalized": "post-traumatic stress disorder",
-          "display": "Post-Traumatic Stress Disorder",
-          "kind": "alias"
-        },
-        {
-          "normalized": "posttraumaticstressdisorder",
-          "display": "Post-Traumatic Stress Disorder",
-          "kind": "alias"
-        },
-        {
-          "normalized": "ptsd",
-          "display": "PTSD",
-          "kind": "alias"
-        },
-        {
-          "normalized": "cshyjfyza",
-          "display": "cshyjfyza",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "cshyjza",
-          "display": "cshyjza",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "cshyjzaptsdp",
-          "display": "cshyjzaptsdp",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "cshylzhq",
-          "display": "cshylzhq",
-          "kind": "pinyin_abbr"
-        },
-        {
-          "normalized": "chuangshanghouyingjizhangaiposttraumaticstressdisorderptsd",
-          "display": "chuangshanghouyingjizhangaiposttraumaticstressdisorderptsd",
-          "kind": "pinyin_full"
-        },
-        {
-          "normalized": "chuang shang hou ya li zheng hou qun ",
-          "display": "创伤后压力症候群",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuang shang hou ying ji fan ying zhang ai ",
-          "display": "创伤后应激反应障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuang shang hou ying ji zhang ai ",
-          "display": "创伤后应激障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuangshanghouyalizhenghouqun",
-          "display": "创伤后压力症候群",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuangshanghouyingjifanyingzhangai",
-          "display": "创伤后应激反应障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuangshanghouyingjizhangai",
-          "display": "创伤后应激障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "创伤后压力症候群",
-          "display": "创伤后压力症候群",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "创伤后应激反应障碍",
-          "display": "创伤后应激反应障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "创伤后应激障碍",
-          "display": "创伤后应激障碍",
-          "kind": "synonym"
-        },
-        {
-          "normalized": "chuang shang hou ying ji zhang ai (post-traumatic stress disorder, ptsd)",
-          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
-          "kind": "title"
-        },
-        {
-          "normalized": "chuangshanghouyingjizhangai(posttraumaticstressdisorder,ptsd)",
-          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
-          "kind": "title"
-        },
-        {
-          "normalized": "创伤后应激障碍（post-traumatic stress disorder, ptsd）",
-          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
-          "kind": "title"
-        },
-        {
-          "normalized": "创伤后应激障碍（posttraumaticstressdisorder,ptsd）",
-          "display": "创伤后应激障碍（Post-Traumatic Stress Disorder, PTSD）",
-          "kind": "title"
-        }
-      ]
-    },
-    {
       "path": "entries/Reconstruction.md",
       "title": "重构（Reconstruction）",
       "aliases": [
         "Reconstruction",
+        "重构",
         "重构（Reconstruction）"
       ],
       "tokens": [
@@ -4407,6 +7898,26 @@
           "normalized": "reconstruction",
           "display": "Reconstruction",
           "kind": "alias"
+        },
+        {
+          "normalized": "zhong gou ",
+          "display": "重构",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zhonggou",
+          "display": "重构",
+          "kind": "alias"
+        },
+        {
+          "normalized": "重构",
+          "display": "重构",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zg",
+          "display": "zg",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zgr",
@@ -4440,6 +7951,7 @@
       "title": "退行（Regression in Psychology）",
       "aliases": [
         "Regression in Psychology",
+        "退行",
         "退行（Regression in Psychology）"
       ],
       "tokens": [
@@ -4452,6 +7964,26 @@
           "normalized": "regressioninpsychology",
           "display": "Regression in Psychology",
           "kind": "alias"
+        },
+        {
+          "normalized": "tui xing ",
+          "display": "退行",
+          "kind": "alias"
+        },
+        {
+          "normalized": "tuixing",
+          "display": "退行",
+          "kind": "alias"
+        },
+        {
+          "normalized": "退行",
+          "display": "退行",
+          "kind": "alias"
+        },
+        {
+          "normalized": "tx",
+          "display": "tx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "txrip",
@@ -4490,13 +8022,42 @@
       "title": "精神分裂症（Schizophrenia，SC）",
       "aliases": [
         "SC",
+        "SC）",
         "Schizophrenia",
+        "Schizophrenia，SC",
+        "精神分裂症",
+        "精神分裂症（Schizophrenia",
         "精神分裂症（Schizophrenia，SC）"
       ],
       "tokens": [
         {
+          "normalized": "jing shen fen lie zheng ",
+          "display": "精神分裂症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jing shen fen lie zheng (schizophrenia",
+          "display": "精神分裂症（Schizophrenia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jingshenfenliezheng",
+          "display": "精神分裂症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jingshenfenliezheng(schizophrenia",
+          "display": "精神分裂症（Schizophrenia",
+          "kind": "alias"
+        },
+        {
           "normalized": "sc",
           "display": "SC",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sc)",
+          "display": "SC）",
           "kind": "alias"
         },
         {
@@ -4505,9 +8066,49 @@
           "kind": "alias"
         },
         {
+          "normalized": "schizophrenia,sc",
+          "display": "Schizophrenia，SC",
+          "kind": "alias"
+        },
+        {
+          "normalized": "schizophrenia，sc",
+          "display": "Schizophrenia，SC",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sc）",
+          "display": "SC）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "精神分裂症",
+          "display": "精神分裂症",
+          "kind": "alias"
+        },
+        {
+          "normalized": "精神分裂症（schizophrenia",
+          "display": "精神分裂症（Schizophrenia",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jsflz",
+          "display": "jsflz",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jsflzs",
+          "display": "jsflzs",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "jsflzss",
           "display": "jsflzss",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "jingshenfenliezhengschizophrenia",
+          "display": "jingshenfenliezhengschizophrenia",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "jingshenfenliezhengschizophreniasc",
@@ -4536,9 +8137,20 @@
       "title": "存在感（Sense of Presence）",
       "aliases": [
         "Sense of Presence",
+        "存在感",
         "存在感（Sense of Presence）"
       ],
       "tokens": [
+        {
+          "normalized": "cun zai gan ",
+          "display": "存在感",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cunzaigan",
+          "display": "存在感",
+          "kind": "alias"
+        },
         {
           "normalized": "sense of presence",
           "display": "Sense of Presence",
@@ -4548,6 +8160,16 @@
           "normalized": "senseofpresence",
           "display": "Sense of Presence",
           "kind": "alias"
+        },
+        {
+          "normalized": "存在感",
+          "display": "存在感",
+          "kind": "alias"
+        },
+        {
+          "normalized": "czg",
+          "display": "czg",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "czgsop",
@@ -4586,9 +8208,20 @@
       "title": "感官调节策略（Sensory Regulation Strategies）",
       "aliases": [
         "Sensory Regulation Strategies",
+        "感官调节策略",
         "感官调节策略（Sensory Regulation Strategies）"
       ],
       "tokens": [
+        {
+          "normalized": "gan guan diao jie ce lue ",
+          "display": "感官调节策略",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ganguandiaojiecelue",
+          "display": "感官调节策略",
+          "kind": "alias"
+        },
         {
           "normalized": "sensory regulation strategies",
           "display": "Sensory Regulation Strategies",
@@ -4598,6 +8231,16 @@
           "normalized": "sensoryregulationstrategies",
           "display": "Sensory Regulation Strategies",
           "kind": "alias"
+        },
+        {
+          "normalized": "感官调节策略",
+          "display": "感官调节策略",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ggdjcl",
+          "display": "ggdjcl",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "ggdjclsrs",
@@ -4636,13 +8279,34 @@
       "title": "封存（Sequestration）",
       "aliases": [
         "Sequestration",
+        "封存",
         "封存（Sequestration）"
       ],
       "tokens": [
         {
+          "normalized": "feng cun ",
+          "display": "封存",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fengcun",
+          "display": "封存",
+          "kind": "alias"
+        },
+        {
           "normalized": "sequestration",
           "display": "Sequestration",
           "kind": "alias"
+        },
+        {
+          "normalized": "封存",
+          "display": "封存",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fc",
+          "display": "fc",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "fcs",
@@ -4676,13 +8340,34 @@
       "title": "傀儡（Servitor）",
       "aliases": [
         "Servitor",
+        "傀儡",
         "傀儡（Servitor）"
       ],
       "tokens": [
         {
+          "normalized": "gui lei ",
+          "display": "傀儡",
+          "kind": "alias"
+        },
+        {
+          "normalized": "guilei",
+          "display": "傀儡",
+          "kind": "alias"
+        },
+        {
           "normalized": "servitor",
           "display": "Servitor",
           "kind": "alias"
+        },
+        {
+          "normalized": "傀儡",
+          "display": "傀儡",
+          "kind": "alias"
+        },
+        {
+          "normalized": "gl",
+          "display": "gl",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "gls",
@@ -4716,13 +8401,42 @@
       "title": "单一类系统（Single-Class Systems, Xianyu Theory）",
       "aliases": [
         "Single-Class Systems",
+        "Single-Class Systems, Xianyu Theory",
         "Xianyu Theory",
+        "Xianyu Theory）",
+        "单一类系统",
+        "单一类系统（Single-Class Systems",
         "单一类系统（Single-Class Systems, Xianyu Theory）"
       ],
       "tokens": [
         {
+          "normalized": "dan yi lei xi tong ",
+          "display": "单一类系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dan yi lei xi tong (single-class systems",
+          "display": "单一类系统（Single-Class Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "danyileixitong",
+          "display": "单一类系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "danyileixitong(singleclasssystems",
+          "display": "单一类系统（Single-Class Systems",
+          "kind": "alias"
+        },
+        {
           "normalized": "single-class systems",
           "display": "Single-Class Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "single-class systems, xianyu theory",
+          "display": "Single-Class Systems, Xianyu Theory",
           "kind": "alias"
         },
         {
@@ -4731,8 +8445,23 @@
           "kind": "alias"
         },
         {
+          "normalized": "singleclasssystems,xianyutheory",
+          "display": "Single-Class Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
           "normalized": "xianyu theory",
           "display": "Xianyu Theory",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory）",
+          "display": "Xianyu Theory）",
           "kind": "alias"
         },
         {
@@ -4741,9 +8470,49 @@
           "kind": "alias"
         },
         {
+          "normalized": "xianyutheory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyutheory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "单一类系统",
+          "display": "单一类系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "单一类系统（single-class systems",
+          "display": "单一类系统（Single-Class Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "单一类系统（singleclasssystems",
+          "display": "单一类系统（Single-Class Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dylxt",
+          "display": "dylxt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "dylxtscs",
+          "display": "dylxtscs",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "dylxtscsxt",
           "display": "dylxtscsxt",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "danyileixitongsingleclasssystems",
+          "display": "danyileixitongsingleclasssystems",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "danyileixitongsingleclasssystemsxianyutheory",
@@ -4777,13 +8546,47 @@
       "title": "躯体化障碍（Somatic Symptom Disorder，SSD）",
       "aliases": [
         "SSD",
+        "SSD）",
         "Somatic Symptom Disorder",
+        "Somatic Symptom Disorder，SSD",
+        "躯体化障碍",
+        "躯体化障碍（Somatic Symptom Disorder",
         "躯体化障碍（Somatic Symptom Disorder，SSD）"
       ],
       "tokens": [
         {
+          "normalized": "qu ti hua zhang ai ",
+          "display": "躯体化障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qu ti hua zhang ai (somatic symptom disorder",
+          "display": "躯体化障碍（Somatic Symptom Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qutihuazhangai",
+          "display": "躯体化障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qutihuazhangai(somaticsymptomdisorder",
+          "display": "躯体化障碍（Somatic Symptom Disorder",
+          "kind": "alias"
+        },
+        {
           "normalized": "somatic symptom disorder",
           "display": "Somatic Symptom Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "somatic symptom disorder,ssd",
+          "display": "Somatic Symptom Disorder，SSD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "somatic symptom disorder，ssd",
+          "display": "Somatic Symptom Disorder，SSD",
           "kind": "alias"
         },
         {
@@ -4792,14 +8595,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "somaticsymptomdisorder,ssd",
+          "display": "Somatic Symptom Disorder，SSD",
+          "kind": "alias"
+        },
+        {
+          "normalized": "somaticsymptomdisorder，ssd",
+          "display": "Somatic Symptom Disorder，SSD",
+          "kind": "alias"
+        },
+        {
           "normalized": "ssd",
           "display": "SSD",
           "kind": "alias"
         },
         {
+          "normalized": "ssd)",
+          "display": "SSD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ssd）",
+          "display": "SSD）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "躯体化障碍",
+          "display": "躯体化障碍",
+          "kind": "alias"
+        },
+        {
+          "normalized": "躯体化障碍（somatic symptom disorder",
+          "display": "躯体化障碍（Somatic Symptom Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "躯体化障碍（somaticsymptomdisorder",
+          "display": "躯体化障碍（Somatic Symptom Disorder",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qthza",
+          "display": "qthza",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qthzassd",
+          "display": "qthzassd",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "qthzassds",
           "display": "qthzassds",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "qutihuazhangaisomaticsymptomdisorder",
+          "display": "qutihuazhangaisomaticsymptomdisorder",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "qutihuazhangaisomaticsymptomdisorderssd",
@@ -4833,7 +8686,11 @@
       "title": "系魂型系统（Soul-Linked Systems, Xianyu Theory）",
       "aliases": [
         "Soul-Linked Systems",
+        "Soul-Linked Systems, Xianyu Theory",
         "Xianyu Theory",
+        "Xianyu Theory）",
+        "系魂型系统",
+        "系魂型系统（Soul-Linked Systems",
         "系魂型系统（Soul-Linked Systems, Xianyu Theory）"
       ],
       "tokens": [
@@ -4843,8 +8700,28 @@
           "kind": "alias"
         },
         {
+          "normalized": "soul-linked systems, xianyu theory",
+          "display": "Soul-Linked Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
           "normalized": "soullinkedsystems",
           "display": "Soul-Linked Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "soullinkedsystems,xianyutheory",
+          "display": "Soul-Linked Systems, Xianyu Theory",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xi hun xing xi tong ",
+          "display": "系魂型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xi hun xing xi tong (soul-linked systems",
+          "display": "系魂型系统（Soul-Linked Systems",
           "kind": "alias"
         },
         {
@@ -4853,14 +8730,74 @@
           "kind": "alias"
         },
         {
+          "normalized": "xianyu theory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyu theory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
           "normalized": "xianyutheory",
           "display": "Xianyu Theory",
           "kind": "alias"
         },
         {
+          "normalized": "xianyutheory)",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xianyutheory）",
+          "display": "Xianyu Theory）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xihunxingxitong",
+          "display": "系魂型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xihunxingxitong(soullinkedsystems",
+          "display": "系魂型系统（Soul-Linked Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "系魂型系统",
+          "display": "系魂型系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "系魂型系统（soul-linked systems",
+          "display": "系魂型系统（Soul-Linked Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "系魂型系统（soullinkedsystems",
+          "display": "系魂型系统（Soul-Linked Systems",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xhxxt",
+          "display": "xhxxt",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xhxxtsls",
+          "display": "xhxxtsls",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "xhxxtslsxt",
           "display": "xhxxtslsxt",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "xihunxingxitongsoullinkedsystems",
+          "display": "xihunxingxitongsoullinkedsystems",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "xihunxingxitongsoullinkedsystemsxianyutheory",
@@ -4894,6 +8831,7 @@
       "title": "系魂（Soulbond）",
       "aliases": [
         "Soulbond",
+        "系魂",
         "系魂（Soulbond）"
       ],
       "tokens": [
@@ -4901,6 +8839,26 @@
           "normalized": "soulbond",
           "display": "Soulbond",
           "kind": "alias"
+        },
+        {
+          "normalized": "xi hun ",
+          "display": "系魂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xihun",
+          "display": "系魂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "系魂",
+          "display": "系魂",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xh",
+          "display": "xh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "xhs",
@@ -4934,7 +8892,11 @@
       "title": "《分裂》（Split, 2016）中的 DID 形象分析",
       "aliases": [
         "2016",
+        "2016）中的 DID 形象分析",
         "Split",
+        "Split, 2016",
+        "《分裂》 中的 DID 形象分析",
+        "《分裂》（Split",
         "《分裂》（Split, 2016）中的 DID 形象分析"
       ],
       "tokens": [
@@ -4944,9 +8906,79 @@
           "kind": "alias"
         },
         {
+          "normalized": "2016)zhong de  did xing xiang fen xi ",
+          "display": "2016）中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "2016)zhongdedidxingxiangfenxi",
+          "display": "2016）中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "2016）中的 did 形象分析",
+          "display": "2016）中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "2016）中的did形象分析",
+          "display": "2016）中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<fen lie >>  zhong de  did xing xiang fen xi ",
+          "display": "《分裂》 中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<fen lie >> (split",
+          "display": "《分裂》（Split",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<fenlie>>(split",
+          "display": "《分裂》（Split",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<fenlie>>zhongdedidxingxiangfenxi",
+          "display": "《分裂》 中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
           "normalized": "split",
           "display": "Split",
           "kind": "alias"
+        },
+        {
+          "normalized": "split, 2016",
+          "display": "Split, 2016",
+          "kind": "alias"
+        },
+        {
+          "normalized": "split,2016",
+          "display": "Split, 2016",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《分裂》 中的 did 形象分析",
+          "display": "《分裂》 中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《分裂》中的did形象分析",
+          "display": "《分裂》 中的 DID 形象分析",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《分裂》（split",
+          "display": "《分裂》（Split",
+          "kind": "alias"
+        },
+        {
+          "normalized": "fls",
+          "display": "fls",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "flszddxxfx",
@@ -4954,8 +8986,33 @@
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "flzddxxfx",
+          "display": "flzddxxfx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "zddxxfx",
+          "display": "zddxxfx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "2016zhongdedidxingxiangfenxi",
+          "display": "2016zhongdedidxingxiangfenxi",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "fenliesplit",
+          "display": "fenliesplit",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "fenliesplit2016zhongdedidxingxiangfenxi",
           "display": "fenliesplit2016zhongdedidxingxiangfenxi",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "fenliezhongdedidxingxiangfenxi",
+          "display": "fenliezhongdedidxingxiangfenxi",
           "kind": "pinyin_full"
         },
         {
@@ -4985,6 +9042,7 @@
       "title": "自发型（Spontaneous）",
       "aliases": [
         "Spontaneous",
+        "自发型",
         "自发型（Spontaneous）"
       ],
       "tokens": [
@@ -4992,6 +9050,26 @@
           "normalized": "spontaneous",
           "display": "Spontaneous",
           "kind": "alias"
+        },
+        {
+          "normalized": "zi fa xing ",
+          "display": "自发型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zifaxing",
+          "display": "自发型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "自发型",
+          "display": "自发型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "zfx",
+          "display": "zfx",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "zfxs",
@@ -5025,6 +9103,7 @@
       "title": "应激反应（Stress Response）",
       "aliases": [
         "Stress Response",
+        "应激反应",
         "应激反应（Stress Response）"
       ],
       "tokens": [
@@ -5037,6 +9116,26 @@
           "normalized": "stressresponse",
           "display": "Stress Response",
           "kind": "alias"
+        },
+        {
+          "normalized": "ying ji fan ying ",
+          "display": "应激反应",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yingjifanying",
+          "display": "应激反应",
+          "kind": "alias"
+        },
+        {
+          "normalized": "应激反应",
+          "display": "应激反应",
+          "kind": "alias"
+        },
+        {
+          "normalized": "yjfy",
+          "display": "yjfy",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "yjfysr",
@@ -5075,9 +9174,20 @@
       "title": "结构性解离理论（Theory of Structural Dissociation）",
       "aliases": [
         "Theory of Structural Dissociation",
+        "结构性解离理论",
         "结构性解离理论（Theory of Structural Dissociation）"
       ],
       "tokens": [
+        {
+          "normalized": "jie gou xing jie chi li lun ",
+          "display": "结构性解离理论",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jiegouxingjiechililun",
+          "display": "结构性解离理论",
+          "kind": "alias"
+        },
         {
           "normalized": "theory of structural dissociation",
           "display": "Theory of Structural Dissociation",
@@ -5087,6 +9197,16 @@
           "normalized": "theoryofstructuraldissociation",
           "display": "Theory of Structural Dissociation",
           "kind": "alias"
+        },
+        {
+          "normalized": "结构性解离理论",
+          "display": "结构性解离理论",
+          "kind": "alias"
+        },
+        {
+          "normalized": "jgxjcll",
+          "display": "jgxjcll",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "jgxjclltosd",
@@ -5125,13 +9245,34 @@
       "title": "切换（Switch）",
       "aliases": [
         "Switch",
+        "切换",
         "切换（Switch）"
       ],
       "tokens": [
         {
+          "normalized": "qie huan ",
+          "display": "切换",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qiehuan",
+          "display": "切换",
+          "kind": "alias"
+        },
+        {
           "normalized": "switch",
           "display": "Switch",
           "kind": "alias"
+        },
+        {
+          "normalized": "切换",
+          "display": "切换",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qh",
+          "display": "qh",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qhs",
@@ -5165,7 +9306,11 @@
       "title": "《西比尔》（Sybil, 1976）与多重人格文化原型",
       "aliases": [
         "1976",
+        "1976）与多重人格文化原型",
         "Sybil",
+        "Sybil, 1976",
+        "《西比尔》 与多重人格文化原型",
+        "《西比尔》（Sybil",
         "《西比尔》（Sybil, 1976）与多重人格文化原型"
       ],
       "tokens": [
@@ -5175,9 +9320,74 @@
           "kind": "alias"
         },
         {
+          "normalized": "1976)yu duo zhong ren ge wen hua yuan xing ",
+          "display": "1976）与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1976)yuduozhongrengewenhuayuanxing",
+          "display": "1976）与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1976）与多重人格文化原型",
+          "display": "1976）与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<xi bi er >>  yu duo zhong ren ge wen hua yuan xing ",
+          "display": "《西比尔》 与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<xi bi er >> (sybil",
+          "display": "《西比尔》（Sybil",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<xibier>>(sybil",
+          "display": "《西比尔》（Sybil",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<xibier>>yuduozhongrengewenhuayuanxing",
+          "display": "《西比尔》 与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
           "normalized": "sybil",
           "display": "Sybil",
           "kind": "alias"
+        },
+        {
+          "normalized": "sybil, 1976",
+          "display": "Sybil, 1976",
+          "kind": "alias"
+        },
+        {
+          "normalized": "sybil,1976",
+          "display": "Sybil, 1976",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《西比尔》 与多重人格文化原型",
+          "display": "《西比尔》 与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《西比尔》与多重人格文化原型",
+          "display": "《西比尔》 与多重人格文化原型",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《西比尔》（sybil",
+          "display": "《西比尔》（Sybil",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xbes",
+          "display": "xbes",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "xbesydzrgwhyx",
@@ -5185,8 +9395,33 @@
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "xbeydzrgwhyx",
+          "display": "xbeydzrgwhyx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "ydzrgwhyx",
+          "display": "ydzrgwhyx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "1976yuduozhongrengewenhuayuanxing",
+          "display": "1976yuduozhongrengewenhuayuanxing",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "xibiersybil",
+          "display": "xibiersybil",
+          "kind": "pinyin_full"
+        },
+        {
           "normalized": "xibiersybil1976yuduozhongrengewenhuayuanxing",
           "display": "xibiersybil1976yuduozhongrengewenhuayuanxing",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "xibieryuduozhongrengewenhuayuanxing",
+          "display": "xibieryuduozhongrengewenhuayuanxing",
           "kind": "pinyin_full"
         },
         {
@@ -5216,9 +9451,20 @@
       "title": "人格职能（System Roles）",
       "aliases": [
         "System Roles",
+        "人格职能",
         "人格职能（System Roles）"
       ],
       "tokens": [
+        {
+          "normalized": "ren ge zhi neng ",
+          "display": "人格职能",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rengezhineng",
+          "display": "人格职能",
+          "kind": "alias"
+        },
         {
           "normalized": "system roles",
           "display": "System Roles",
@@ -5228,6 +9474,16 @@
           "normalized": "systemroles",
           "display": "System Roles",
           "kind": "alias"
+        },
+        {
+          "normalized": "人格职能",
+          "display": "人格职能",
+          "kind": "alias"
+        },
+        {
+          "normalized": "rgzn",
+          "display": "rgzn",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "rgznsr",
@@ -5266,6 +9522,7 @@
       "title": "系统（System）",
       "aliases": [
         "System",
+        "系统",
         "系统（System）"
       ],
       "tokens": [
@@ -5273,6 +9530,26 @@
           "normalized": "system",
           "display": "System",
           "kind": "alias"
+        },
+        {
+          "normalized": "xi tong ",
+          "display": "系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xitong",
+          "display": "系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "系统",
+          "display": "系统",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xt",
+          "display": "xt",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "xts",
@@ -5306,9 +9583,20 @@
       "title": "青少年意识体（Teen Part）",
       "aliases": [
         "Teen Part",
+        "青少年意识体",
         "青少年意识体（Teen Part）"
       ],
       "tokens": [
+        {
+          "normalized": "qing shao nian yi shi ti ",
+          "display": "青少年意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qingshaonianyishiti",
+          "display": "青少年意识体",
+          "kind": "alias"
+        },
         {
           "normalized": "teen part",
           "display": "Teen Part",
@@ -5318,6 +9606,16 @@
           "normalized": "teenpart",
           "display": "Teen Part",
           "kind": "alias"
+        },
+        {
+          "normalized": "青少年意识体",
+          "display": "青少年意识体",
+          "kind": "alias"
+        },
+        {
+          "normalized": "qsnyst",
+          "display": "qsnyst",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "qsnysttp",
@@ -5356,7 +9654,11 @@
       "title": "《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现",
       "aliases": [
         "1957",
+        "1957）对解离的早期影视再现",
         "The Three Faces of Eve",
+        "The Three Faces of Eve, 1957",
+        "《三面夏娃》 对解离的早期影视再现",
+        "《三面夏娃》（The Three Faces of Eve",
         "《三面夏娃》（The Three Faces of Eve, 1957）对解离的早期影视再现"
       ],
       "tokens": [
@@ -5366,8 +9668,48 @@
           "kind": "alias"
         },
         {
+          "normalized": "1957)dui jie chi de zao qi ying shi zai xian ",
+          "display": "1957）对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1957)duijiechidezaoqiyingshizaixian",
+          "display": "1957）对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "1957）对解离的早期影视再现",
+          "display": "1957）对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<san mian xia wa >>  dui jie chi de zao qi ying shi zai xian ",
+          "display": "《三面夏娃》 对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<san mian xia wa >> (the three faces of eve",
+          "display": "《三面夏娃》（The Three Faces of Eve",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<sanmianxiawa>>(thethreefacesofeve",
+          "display": "《三面夏娃》（The Three Faces of Eve",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<sanmianxiawa>>duijiechidezaoqiyingshizaixian",
+          "display": "《三面夏娃》 对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
           "normalized": "the three faces of eve",
           "display": "The Three Faces of Eve",
+          "kind": "alias"
+        },
+        {
+          "normalized": "the three faces of eve, 1957",
+          "display": "The Three Faces of Eve, 1957",
           "kind": "alias"
         },
         {
@@ -5376,9 +9718,64 @@
           "kind": "alias"
         },
         {
+          "normalized": "thethreefacesofeve,1957",
+          "display": "The Three Faces of Eve, 1957",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《三面夏娃》 对解离的早期影视再现",
+          "display": "《三面夏娃》 对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《三面夏娃》对解离的早期影视再现",
+          "display": "《三面夏娃》 对解离的早期影视再现",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《三面夏娃》（the three faces of eve",
+          "display": "《三面夏娃》（The Three Faces of Eve",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《三面夏娃》（thethreefacesofeve",
+          "display": "《三面夏娃》（The Three Faces of Eve",
+          "kind": "alias"
+        },
+        {
+          "normalized": "djcdzqyszx",
+          "display": "djcdzqyszx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "smxwdjcdzqyszx",
+          "display": "smxwdjcdzqyszx",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "smxwttfoe",
+          "display": "smxwttfoe",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "smxwttfoedjcdzqyszx",
           "display": "smxwttfoedjcdzqyszx",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "1957duijiechidezaoqiyingshizaixian",
+          "display": "1957duijiechidezaoqiyingshizaixian",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "sanmianxiawaduijiechidezaoqiyingshizaixian",
+          "display": "sanmianxiawaduijiechidezaoqiyingshizaixian",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "sanmianxiawathethreefacesofeve",
+          "display": "sanmianxiawathethreefacesofeve",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "sanmianxiawathethreefacesofeve1957duijiechidezaoqiyingshizaixian",
@@ -5412,9 +9809,20 @@
       "title": "《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）",
       "aliases": [
         "Touhou Tulpa Fandom",
+        "《东方Project》同人圈中的 Tulpa 文化解读",
         "《东方Project》同人圈中的 Tulpa 文化解读（Touhou Tulpa Fandom）"
       ],
       "tokens": [
+        {
+          "normalized": "<<dong fang project>> tong ren quan zhong de  tulpa wen hua jie du ",
+          "display": "《东方Project》同人圈中的 Tulpa 文化解读",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<dongfangproject>>tongrenquanzhongdetulpawenhuajiedu",
+          "display": "《东方Project》同人圈中的 Tulpa 文化解读",
+          "kind": "alias"
+        },
         {
           "normalized": "touhou tulpa fandom",
           "display": "Touhou Tulpa Fandom",
@@ -5426,9 +9834,29 @@
           "kind": "alias"
         },
         {
+          "normalized": "《东方project》同人圈中的 tulpa 文化解读",
+          "display": "《东方Project》同人圈中的 Tulpa 文化解读",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《东方project》同人圈中的tulpa文化解读",
+          "display": "《东方Project》同人圈中的 Tulpa 文化解读",
+          "kind": "alias"
+        },
+        {
+          "normalized": "dfptrqzdtwhjd",
+          "display": "dfptrqzdtwhjd",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "dfptrqzdtwhjdttf",
           "display": "dfptrqzdtwhjdttf",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "dongfangprojecttongrenquanzhongdetulpawenhuajiedu",
+          "display": "dongfangprojecttongrenquanzhongdetulpawenhuajiedu",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "dongfangprojecttongrenquanzhongdetulpawenhuajiedutouhoutulpafandom",
@@ -5463,15 +9891,36 @@
       "aliases": [
         "Trauma",
         "chuangshang",
+        "创伤",
         "创伤（Trauma）",
         "心理创伤",
         "精神创伤"
       ],
       "tokens": [
         {
+          "normalized": "chuang shang ",
+          "display": "创伤",
+          "kind": "alias"
+        },
+        {
+          "normalized": "chuangshang",
+          "display": "创伤",
+          "kind": "alias"
+        },
+        {
           "normalized": "trauma",
           "display": "Trauma",
           "kind": "alias"
+        },
+        {
+          "normalized": "创伤",
+          "display": "创伤",
+          "kind": "alias"
+        },
+        {
+          "normalized": "cs",
+          "display": "cs",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "cst",
@@ -5492,11 +9941,6 @@
           "normalized": "chuangshangtrauma",
           "display": "chuangshangtrauma",
           "kind": "pinyin_full"
-        },
-        {
-          "normalized": "chuangshang",
-          "display": "chuangshang",
-          "kind": "synonym"
         },
         {
           "normalized": "jing shen chuang shang ",
@@ -5550,13 +9994,34 @@
       "title": "触发（Trigger）",
       "aliases": [
         "Trigger",
+        "触发",
         "触发（Trigger）"
       ],
       "tokens": [
         {
+          "normalized": "hong fa ",
+          "display": "触发",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hongfa",
+          "display": "触发",
+          "kind": "alias"
+        },
+        {
           "normalized": "trigger",
           "display": "Trigger",
           "kind": "alias"
+        },
+        {
+          "normalized": "触发",
+          "display": "触发",
+          "kind": "alias"
+        },
+        {
+          "normalized": "hf",
+          "display": "hf",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "hft",
@@ -5590,13 +10055,34 @@
       "title": "图帕（Tulpa）",
       "aliases": [
         "Tulpa",
+        "图帕",
         "图帕（Tulpa）"
       ],
       "tokens": [
         {
+          "normalized": "tu pa ",
+          "display": "图帕",
+          "kind": "alias"
+        },
+        {
           "normalized": "tulpa",
           "display": "Tulpa",
           "kind": "alias"
+        },
+        {
+          "normalized": "tupa",
+          "display": "图帕",
+          "kind": "alias"
+        },
+        {
+          "normalized": "图帕",
+          "display": "图帕",
+          "kind": "alias"
+        },
+        {
+          "normalized": "tp",
+          "display": "tp",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "tpt",
@@ -5629,14 +10115,40 @@
       "path": "entries/Tulpish.md",
       "title": "T 语（Tulpish）",
       "aliases": [
+        "T 语",
         "T 语（Tulpish）",
         "Tulpish"
       ],
       "tokens": [
         {
+          "normalized": "t yu ",
+          "display": "T 语",
+          "kind": "alias"
+        },
+        {
+          "normalized": "t 语",
+          "display": "T 语",
+          "kind": "alias"
+        },
+        {
           "normalized": "tulpish",
           "display": "Tulpish",
           "kind": "alias"
+        },
+        {
+          "normalized": "tyu",
+          "display": "T 语",
+          "kind": "alias"
+        },
+        {
+          "normalized": "t语",
+          "display": "T 语",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ty",
+          "display": "ty",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "tyt",
@@ -5675,9 +10187,20 @@
       "title": "《我与梦露的一周》（The United States of Tara）中的系统家庭日常",
       "aliases": [
         "The United States of Tara",
+        "《我与梦露的一周》 中的系统家庭日常",
         "《我与梦露的一周》（The United States of Tara）中的系统家庭日常"
       ],
       "tokens": [
+        {
+          "normalized": "<<wo yu meng lu de yi zhou >>  zhong de xi tong jia ting ri chang ",
+          "display": "《我与梦露的一周》 中的系统家庭日常",
+          "kind": "alias"
+        },
+        {
+          "normalized": "<<woyumengludeyizhou>>zhongdexitongjiatingrichang",
+          "display": "《我与梦露的一周》 中的系统家庭日常",
+          "kind": "alias"
+        },
         {
           "normalized": "the united states of tara",
           "display": "The United States of Tara",
@@ -5689,13 +10212,33 @@
           "kind": "alias"
         },
         {
+          "normalized": "《我与梦露的一周》 中的系统家庭日常",
+          "display": "《我与梦露的一周》 中的系统家庭日常",
+          "kind": "alias"
+        },
+        {
+          "normalized": "《我与梦露的一周》中的系统家庭日常",
+          "display": "《我与梦露的一周》 中的系统家庭日常",
+          "kind": "alias"
+        },
+        {
           "normalized": "wymldyztusotzdxtjtrc",
           "display": "wymldyztusotzdxtjtrc",
           "kind": "pinyin_abbr"
         },
         {
+          "normalized": "wymldyzzdxtjtrc",
+          "display": "wymldyzzdxtjtrc",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "woyumengludeyizhoutheunitedstatesoftarazhongdexitongjiatingrichang",
           "display": "woyumengludeyizhoutheunitedstatesoftarazhongdexitongjiatingrichang",
+          "kind": "pinyin_full"
+        },
+        {
+          "normalized": "woyumengludeyizhouzhongdexitongjiatingrichang",
+          "display": "woyumengludeyizhouzhongdexitongjiatingrichang",
           "kind": "pinyin_full"
         },
         {
@@ -5725,7 +10268,11 @@
       "title": "内视（Visualization / Imagination）",
       "aliases": [
         "Imagination",
+        "Imagination）",
         "Visualization",
+        "Visualization / Imagination",
+        "内视",
+        "内视（Visualization",
         "内视（Visualization / Imagination）"
       ],
       "tokens": [
@@ -5735,14 +10282,79 @@
           "kind": "alias"
         },
         {
+          "normalized": "imagination)",
+          "display": "Imagination）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "imagination）",
+          "display": "Imagination）",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei shi ",
+          "display": "内视",
+          "kind": "alias"
+        },
+        {
+          "normalized": "nei shi (visualization",
+          "display": "内视（Visualization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neishi",
+          "display": "内视",
+          "kind": "alias"
+        },
+        {
+          "normalized": "neishi(visualization",
+          "display": "内视（Visualization",
+          "kind": "alias"
+        },
+        {
           "normalized": "visualization",
           "display": "Visualization",
           "kind": "alias"
         },
         {
+          "normalized": "visualization / imagination",
+          "display": "Visualization / Imagination",
+          "kind": "alias"
+        },
+        {
+          "normalized": "visualizationimagination",
+          "display": "Visualization / Imagination",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内视",
+          "display": "内视",
+          "kind": "alias"
+        },
+        {
+          "normalized": "内视（visualization",
+          "display": "内视（Visualization",
+          "kind": "alias"
+        },
+        {
+          "normalized": "ns",
+          "display": "ns",
+          "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "nsv",
+          "display": "nsv",
+          "kind": "pinyin_abbr"
+        },
+        {
           "normalized": "nsvi",
           "display": "nsvi",
           "kind": "pinyin_abbr"
+        },
+        {
+          "normalized": "neishivisualization",
+          "display": "neishivisualization",
+          "kind": "pinyin_full"
         },
         {
           "normalized": "neishivisualizationimagination",
@@ -5776,18 +10388,39 @@
       "title": "弦羽理论生态位分类法（Xianyu Theory of Niche Classification）",
       "aliases": [
         "Xianyu Theory of Niche Classification",
+        "弦羽理论生态位分类法",
         "弦羽理论生态位分类法（Xianyu Theory of Niche Classification）"
       ],
       "tokens": [
+        {
+          "normalized": "xian yu li lun sheng tai wei fen lei fa ",
+          "display": "弦羽理论生态位分类法",
+          "kind": "alias"
+        },
         {
           "normalized": "xianyu theory of niche classification",
           "display": "Xianyu Theory of Niche Classification",
           "kind": "alias"
         },
         {
+          "normalized": "xianyulilunshengtaiweifenleifa",
+          "display": "弦羽理论生态位分类法",
+          "kind": "alias"
+        },
+        {
           "normalized": "xianyutheoryofnicheclassification",
           "display": "Xianyu Theory of Niche Classification",
           "kind": "alias"
+        },
+        {
+          "normalized": "弦羽理论生态位分类法",
+          "display": "弦羽理论生态位分类法",
+          "kind": "alias"
+        },
+        {
+          "normalized": "xyllstwflf",
+          "display": "xyllstwflf",
+          "kind": "pinyin_abbr"
         },
         {
           "normalized": "xyllstwflfxtonc",


### PR DESCRIPTION
## 动机
- Docsify 搜索索引未能从标题中抽取括号外的原文，导致仅能以带括号的形式匹配词条

## 主要变更
- 调整 `tools/build_search_index.py` 的 `iter_title_variants`，同时输出原文、去括号文本与括号中的别名
- 重新生成 `assets/search-index.json` 以纳入新的别名与拼音变体

## 风险
- 变更影响搜索索引生成逻辑，需要关注是否对其他词条造成意外拆分

## 相关条目
- `entries/Dissociation.md`


------
https://chatgpt.com/codex/tasks/task_e_68e0e158d88c8333866e24a98a49dba6