### PR TITLE
修复 PDF 导出字体覆盖问题

### DIFF
--- a/docs/pdf_export/README_pdf_output.md
+++ b/docs/pdf_export/README_pdf_output.md
@@ -37,6 +37,15 @@ python tools/pdf_export/export_to_pdf.py --cjk-font "Noto Serif CJK SC"
 python tools/pdf_export/export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei" # Windows
 ```
 
+当指定了 `--cjk-font` 而未提供 `--main-font` 时，脚本会自动将主字体与中文字体保持一致，避免罗马数字（Ⅰ、Ⅱ 等）或数学符号在 `tectonic` 等引擎下回退为缺字方框。若需要分别为正文、无衬线与等宽文本配置不同字体，可使用下列参数：
+
+```bash
+python tools/pdf_export/export_to_pdf.py --main-font "Noto Serif" --cjk-font "Noto Serif CJK SC"
+python tools/pdf_export/export_to_pdf.py --sans-font "Noto Sans" --mono-font "JetBrains Mono"
+```
+
+上述字体参数会分别映射到 Pandoc 的 `mainfont`、`sansfont`、`monofont` 变量，可灵活组合使用。
+
 脚本会自动检测上述常见引擎，如果缺失会提示安装方式。也可以通过 `--pdf-engine` 参数显式指定要使用的引擎，例如：
 
 ```bash

--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -39,6 +39,15 @@ python tools/pdf_export/export_to_pdf.py --cjk-font "Noto Serif CJK SC"
 python tools/pdf_export/export_to_pdf.py --pdf-engine=tectonic --cjk-font="Microsoft YaHei" # Windows
 ```
 
+当指定了 `--cjk-font` 而未提供 `--main-font` 时，脚本会自动将主字体与中文字体保持一致，避免罗马数字（Ⅰ、Ⅱ 等）或数学符号在 `tectonic` 等引擎下回退为缺字方框。若需要分别为正文、无衬线与等宽文本配置不同字体，可使用下列参数：
+
+```bash
+python tools/pdf_export/export_to_pdf.py --main-font "Noto Serif" --cjk-font "Noto Serif CJK SC"
+python tools/pdf_export/export_to_pdf.py --sans-font "Noto Sans" --mono-font "JetBrains Mono"
+```
+
+上述字体参数会分别映射到 Pandoc 的 `mainfont`、`sansfont`、`monofont` 变量，可灵活组合使用。
+
 脚本会自动检测上述常见引擎，如果缺失会提示安装方式。也可以通过 `--pdf-engine` 参数显式指定要使用的引擎，例如：
 
 ```bash

--- a/tools/pdf_export/pdf_export/exporter.py
+++ b/tools/pdf_export/pdf_export/exporter.py
@@ -15,6 +15,9 @@ def export_pdf(
     pandoc_cmd: str,
     pdf_engine: str | None,
     cjk_font: str | None,
+    main_font: str | None,
+    sans_font: str | None,
+    mono_font: str | None,
 ) -> None:
     """调用 Pandoc 将 ``markdown_content`` 渲染为 ``output_path`` 指定的文件。"""
 
@@ -36,8 +39,18 @@ def export_pdf(
     if pdf_engine:
         command.extend(["--pdf-engine", pdf_engine])
 
+    font_variables: list[tuple[str, str]] = []
+    if main_font:
+        font_variables.append(("mainfont", main_font))
+    if sans_font:
+        font_variables.append(("sansfont", sans_font))
+    if mono_font:
+        font_variables.append(("monofont", mono_font))
     if cjk_font:
-        command.extend(["--variable", f"CJKmainfont={cjk_font}"])
+        font_variables.append(("CJKmainfont", cjk_font))
+
+    for key, value in font_variables:
+        command.extend(["--variable", f"{key}={value}"])
 
     try:
         result = subprocess.run(


### PR DESCRIPTION
## 概要
- 新增 PDF 导出命令行的主字体、无衬线字体与等宽字体参数，并在仅指定中文字体时自动作为主字体使用，避免特殊字符缺字
- 更新 Pandoc 调用逻辑，同时传递 mainfont/sansfont/monofont 变量以确保字体覆盖
- 同步更新 PDF 导出文档，说明新的字体选项与默认行为

## 测试
- python -m compileall tools/pdf_export/export_to_pdf.py tools/pdf_export/pdf_export

------
https://chatgpt.com/codex/tasks/task_e_68e0eb04c2f88333becd1d48ca4a8e6f