### PR TITLE
修复索引导航导致的404跳转问题

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,12 @@
 
           const isAbsolutePath =
             rawPath.startsWith("/") || rawPath.startsWith("entries/");
+          const isRootDocumentLink =
+            !isAbsolutePath &&
+            !rawPath.startsWith(".") &&
+            rawPath.length > 0 &&
+            !rawPath.includes("/") &&
+            /\.(md|html)$/i.test(rawPath);
           const baseTrimmed = basePath.replace(/^\/+|\/+$/g, "");
           let workingPath = rawPath.replace(/^\/+/, "");
           if (baseTrimmed && workingPath.startsWith(`${baseTrimmed}/`)) {
@@ -131,7 +137,10 @@
             .split("/")
             .filter((segment) => segment.length);
 
-          const stack = isAbsolutePath ? [] : [...currentBaseSegments];
+          const stack =
+            isAbsolutePath || isRootDocumentLink
+              ? []
+              : [...currentBaseSegments];
 
           for (const segment of pathSegments) {
             if (segment === ".") continue;
@@ -262,9 +271,17 @@
         function routeToRepoPath(routePath) {
           if (!routePath) return null;
           let path = routePath.replace(/^\//, "");
-          if (path.endsWith("/")) path = path.slice(0, -1);
-          if (!path) return null;
-          return decodeURIComponent(path) + ".md";
+          const [rawPath] = path.split("?");
+          if (!rawPath) return null;
+          const trimmed = rawPath.endsWith("/")
+            ? rawPath.slice(0, -1)
+            : rawPath;
+          if (!trimmed) return null;
+          const decoded = decodeURIComponent(trimmed);
+          if (/\.[^./]+$/i.test(decoded)) {
+            return decoded;
+          }
+          return `${decoded}.md`;
         }
 
         function formatDate(isoString) {


### PR DESCRIPTION
## 摘要
- 调整 Docsify 链接解析逻辑，识别根目录下的 Markdown/HTML 链接，避免在词条页点击后被误解析为相对子路径
- 修正最后更新时间映射函数，正确处理带查询参数的路由并保留已有扩展名

## 测试
- 手动本地预览：`npx docsify serve . --port 3000`

------
https://chatgpt.com/codex/tasks/task_e_68e24e75e284833397434e54c8587e55