### PR TITLE
fix: 确保触发警告兼容 PDF 导出

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -389,6 +389,51 @@ button, .cover .buttons a{
   color: color-mix(in oklab, var(--c-brand) 62%, rgba(246,250,255,.82));
 }
 
+/* 触发警告卡片 */
+.trigger-warning-card{
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  margin: 0 0 1.2rem;
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklab, #F97316 28%, transparent);
+  background: color-mix(in oklab, #F97316 8%, var(--c-card));
+  box-shadow: 0 8px 22px rgba(249, 115, 22, 0.12);
+}
+
+.trigger-warning-card__icon{
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+}
+
+.trigger-warning-card__text{
+  margin: 0;
+  color: var(--c-text);
+  line-height: 1.65;
+}
+
+:root.dark .trigger-warning-card{
+  border-color: color-mix(in oklab, #F97316 42%, transparent);
+  background: color-mix(in oklab, rgba(249, 115, 22, 0.22) 55%, var(--c-card));
+  box-shadow: 0 14px 28px rgba(249, 115, 22, 0.28);
+}
+
+:root.dark .trigger-warning-card__text{
+  color: color-mix(in oklab, var(--c-text) 88%, rgba(255, 255, 255, 0.85));
+}
+
+.trigger-warning-card strong{
+  font-weight: 700;
+}
+
+@media (max-width: 640px){
+  .trigger-warning-card{
+    align-items: flex-start;
+  }
+}
+
 /* 表格美化 */
 .markdown-section table{
   width: 100%;

--- a/assets/trigger-warning.svg
+++ b/assets/trigger-warning.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title>触发警告</title>
+  <desc>橙色背景中的警示符号</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FDBA74" />
+      <stop offset="100%" stop-color="#F97316" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#gradient)" />
+  <path
+    d="M32 14a4 4 0 0 0-3.5 2L14 44.5c-.9 1.6-.9 3.4 0 5a4 4 0 0 0 3.5 2h29c1.5 0 2.8-.8 3.5-2 1-1.6 1-3.4 0-5L35.5 16a4 4 0 0 0-3.5-2Z"
+    fill="#fff"
+    opacity="0.85"
+  />
+  <path
+    d="M32 23c1.2 0 2.2.9 2.3 2.1l.7 12c.1 1.3-.9 2.4-2.3 2.4s-2.4-1.1-2.3-2.4l.7-12c.1-1.2 1.1-2.1 2.3-2.1Z"
+    fill="#F97316"
+  />
+  <circle cx="32" cy="42" r="3" fill="#F97316" />
+</svg>

--- a/docs/pdf_export/README_pdf_output.md
+++ b/docs/pdf_export/README_pdf_output.md
@@ -18,8 +18,9 @@ cd tools/pdf_export && python -m pdf_export
 4. 生成独立的封面页与目录页（目录中的词条名称可直接点击跳转至对应内容）；
 5. 为每个章节中的词条单独开启新页面，并自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
 6. 自动识别 Markdown 中以 `entries/*.md` 形式书写的词条链接，并在合并时重写为指向 PDF 内部锚点的链接，确保离线文档中的交叉跳转仍可点击；
-7. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
-8. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
+7. 将 `index.md` 中以 `<!-- trigger-warning:start -->…<!-- trigger-warning:end -->` 包裹的触发警告区块转换为 `> ⚠️ …` 的 Markdown 语法，避免原生 HTML 在 PDF 中缺失；
+8. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
+9. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 > ℹ️ 所有被导出的词条都必须在 Frontmatter 中声明 `title`、`tags`、`updated` 字段。`updated` 支持写成 `YYYY-MM-DD` 字符串或 YAML 自动识别的日期字面量，两种写法都会在导出时转换为同一格式。若将字段留空、显式写成 `null` 或填写布尔值/列表，脚本会提示“updated 字段必须为非空字符串或有效日期”。
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -93,6 +93,7 @@ markdownlint "**/*.md" --ignore "node_modules" --ignore "tools/pdf_export/vendor
 - `tools/pdf_export/` 在导出 PDF 时会优先读取仓库根目录的 `index.md`，目录页与章节书签都会遵循该文件的分组与顺序；
 - 若 `index.md` 缺失或未收录全部词条，未出现在目录中的文档会自动归入“未索引词条”章节，确保不会遗漏内容；
 - 目录中的词条链接会自动重写为 PDF 内部锚点，确保离线文档中的跳转行为与线上一致。
+- `index.md` 中通过 `<!-- trigger-warning:start -->…<!-- trigger-warning:end -->` 包裹的触发警告区块，会在导出时转换为 `> ⚠️ …` 的 Markdown 形式，确保目录页在 PDF 中保留警示文本。
 - 词条 Frontmatter 的 `updated` 字段支持 `YYYY-MM-DD` 字符串或 YAML 日期字面量，若留空、写成 `null`、布尔值或列表，导出脚本会终止并提示修正。
 
 ## 相关文档

--- a/index.md
+++ b/index.md
@@ -5,6 +5,19 @@
 
 ## 诊断与临床
 
+<!-- trigger-warning:start -->
+<div class="trigger-warning-card">
+  <img
+    src="./assets/trigger-warning.svg"
+    alt="触发警告"
+    class="trigger-warning-card__icon"
+  />
+  <p class="trigger-warning-card__text">
+    <strong>触发警告：</strong>本节条目涉及创伤、精神健康等敏感主题，可能唤起不适回忆，请在安全状态下阅读并注意自我照顾。
+  </p>
+</div>
+<!-- trigger-warning:end -->
+
 - [创伤（Trauma）](entries/Trauma.md)
 - [创伤后应激障碍（PTSD）](entries/PTSD.md)
 - [复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)

--- a/tools/pdf_export/README_pdf_output.md
+++ b/tools/pdf_export/README_pdf_output.md
@@ -20,8 +20,9 @@ cd tools/pdf_export && python -m pdf_export
 4. 在合并内容前，会优先插入项目根目录下的 `Preface.md`（若存在且未被忽略），以确保 PDF 以《前言》开篇；
 5. 收集索引及兜底章节列出的 Markdown 文件并按顺序合并，同时在 PDF 中为每个 Markdown 文件单独开启新页面，并在 PDF 大纲中按分类组织；在合并过程中会自动移除词条自身的一级标题，避免 PDF 中出现重复标题；
 6. 自动识别 Markdown 中以 `entries/*.md` 形式书写的词条链接，并在合并时重写为指向 PDF 内部锚点的链接，确保离线文档中的交叉跳转仍可点击；
-7. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
-8. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
+7. 将 `index.md` 中以 `<!-- trigger-warning:start -->…<!-- trigger-warning:end -->` 包裹的触发警告区块转换为 `> ⚠️ …` 的 Markdown 语法，避免原生 HTML 在 PDF 中缺失；
+8. 如果 `assets/last-updated.json` 存在，则会读取索引并在每篇词条标题下插入“🕒 最后更新：2025/10/02 12:34:56（abc1234）”提示，使离线 PDF 与线上页面保持一致；
+9. 调用 [Pandoc](https://pandoc.org/) 生成排好版的 `plurality_wiki.pdf`。
 
 > ℹ️ 所有被导出的词条都必须在 Frontmatter 中声明 `title`、`tags`、`updated` 字段。`updated` 支持写成 `YYYY-MM-DD` 字符串或 YAML 自动识别的日期字面量，两种写法都会在导出时转换为同一格式。若将字段留空、显式写成 `null` 或填写布尔值/列表，脚本会提示“updated 字段必须为非空字符串或有效日期”。
 


### PR DESCRIPTION
## 概述
- 在 `index.md` 中为触发警告卡片添加标记注释，方便导出流程识别
- 调整 PDF 导出脚本，自动将触发警告卡片转换为 PDF 友好的 Markdown，并补充相关文档说明

## 测试
- `python -m compileall tools/pdf_export/pdf_export/markdown.py`


------
https://chatgpt.com/codex/tasks/task_e_68e251a097848333a88b5e1472e32de4