### PR TITLE
style: 调整触发警告卡片尺寸

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -394,7 +394,7 @@ button, .cover .buttons a{
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 14px 16px;
+  padding: 12px 14px;
   margin: 0 0 1.2rem;
   border-radius: var(--radius);
   border: 1px solid color-mix(in oklab, #F97316 28%, transparent);
@@ -403,15 +403,16 @@ button, .cover .buttons a{
 }
 
 .trigger-warning-card__icon{
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
   flex-shrink: 0;
 }
 
 .trigger-warning-card__text{
   margin: 0;
   color: var(--c-text);
-  line-height: 1.65;
+  font-size: .95rem;
+  line-height: 1.55;
 }
 
 :root.dark .trigger-warning-card{


### PR DESCRIPTION
## 概述
- 缩减触发警告卡片的内边距、图标尺寸和文字排版，让视觉占比更小

## 测试
- 手动预览 http://localhost:3000/#/index 确认警示卡片展示正常

------
https://chatgpt.com/codex/tasks/task_e_68e25d57b22083339ff4a04443d6e54d