### PR TITLE
style: 调整触发警告卡片居中样式

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -393,6 +393,7 @@ button, .cover .buttons a{
 .trigger-warning-card{
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 14px;
   padding: 12px 14px;
   margin: 0 0 1.2rem;
@@ -400,6 +401,7 @@ button, .cover .buttons a{
   border: 1px solid color-mix(in oklab, #F97316 28%, transparent);
   background: color-mix(in oklab, #F97316 8%, var(--c-card));
   box-shadow: 0 8px 22px rgba(249, 115, 22, 0.12);
+  text-align: center;
 }
 
 .trigger-warning-card__icon{
@@ -431,7 +433,8 @@ button, .cover .buttons a{
 
 @media (max-width: 640px){
   .trigger-warning-card{
-    align-items: flex-start;
+    align-items: center;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## 摘要
- 为触发警告卡片补充水平居中与文本居中样式，使图标与说明文字保持统一视觉对齐
- 调整移动端断点下的对齐方式，确保小屏幕也能居中展示

## 测试
- 未执行自动化测试（样式变更）

------
https://chatgpt.com/codex/tasks/task_e_68e260d18dec83338870873cbab3ca8e