### PR TITLE
重写 MkDocs 首页布局与样式

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -191,3 +191,359 @@ article li {
     font-size: 1.3em;
   }
 }
+
+/* ===== 首页定制样式 ===== */
+:root {
+  --home-card-bg: rgba(255, 255, 255, 0.96);
+  --home-card-border: rgba(0, 0, 0, 0.08);
+  --home-hero-gradient-start: rgba(79, 192, 141, 0.16);
+  --home-hero-gradient-end: rgba(64, 152, 255, 0.12);
+}
+
+[data-md-color-scheme="slate"] {
+  --home-card-bg: rgba(23, 30, 40, 0.92);
+  --home-card-border: rgba(255, 255, 255, 0.14);
+  --home-hero-gradient-start: rgba(79, 192, 141, 0.32);
+  --home-hero-gradient-end: rgba(64, 152, 255, 0.28);
+}
+
+.home-hero {
+  margin: 1.5rem 0 2.5rem;
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, var(--home-hero-gradient-start), var(--home-hero-gradient-end));
+  border: 1px solid var(--home-card-border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.home-hero__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.home-hero__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background-color: rgba(0, 0, 0, 0.08);
+  color: inherit;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+[data-md-color-scheme="slate"] .home-hero__tag {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.home-hero__content h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  line-height: 1.2;
+}
+
+.home-hero__content p {
+  font-size: 1.05rem;
+  margin-bottom: 1.5rem;
+}
+
+.home-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.home-hero__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background-color: rgba(255, 255, 255, 0.2);
+  color: inherit;
+}
+
+.home-hero__btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.home-hero__btn--primary {
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.home-hero__aside {
+  padding: 1.5rem;
+  border-radius: 16px;
+  background-color: rgba(255, 255, 255, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+[data-md-color-scheme="slate"] .home-hero__aside {
+  background-color: rgba(15, 23, 42, 0.45);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.home-hero__aside h3 {
+  margin-top: 0;
+}
+
+.home-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.home-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.home-card {
+  background-color: var(--home-card-bg);
+  border-radius: 20px;
+  border: 1px solid var(--home-card-border);
+  padding: 1.75rem;
+  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.home-card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.home-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.home-card__hint {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.65);
+  margin-bottom: 1rem;
+}
+
+[data-md-color-scheme="slate"] .home-card__hint {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.home-alert {
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  font-weight: 500;
+}
+
+.home-alert--warning {
+  background-color: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.home-alert--info {
+  background-color: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+[data-md-color-scheme="slate"] .home-alert--warning {
+  background-color: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+[data-md-color-scheme="slate"] .home-alert--info {
+  background-color: rgba(96, 165, 250, 0.2);
+  border-color: rgba(96, 165, 250, 0.32);
+}
+
+.home-recent-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0 0 1rem;
+}
+
+.home-recent-list li + li {
+  margin-top: 0.5rem;
+}
+
+.home-recent-list a {
+  font-weight: 600;
+}
+
+.quick-links-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1rem;
+}
+
+.quick-link-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 16px;
+  text-decoration: none;
+  background-color: rgba(255, 255, 255, 0.65);
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: inherit;
+}
+
+.quick-link-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--md-primary-fg-color);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+[data-md-color-scheme="slate"] .quick-link-card {
+  background-color: rgba(30, 41, 59, 0.7);
+}
+
+.quick-link-icon {
+  font-size: 1.6rem;
+}
+
+.quick-link-body h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.quick-link-body p {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+}
+
+.quick-link-arrow {
+  margin-left: auto;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.step-list {
+  counter-reset: step;
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.step-list li {
+  position: relative;
+  padding-left: 2.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.step-list li:last-child {
+  margin-bottom: 0;
+}
+
+.step-list li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0.2rem;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.badge-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(79, 192, 141, 0.18);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+[data-md-color-scheme="slate"] .badge {
+  background-color: rgba(79, 192, 141, 0.28);
+}
+
+.featured-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0 0 1rem;
+}
+
+.featured-list li + li {
+  margin-top: 0.6rem;
+}
+
+.home-footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background-color: rgba(79, 192, 141, 0.1);
+  border: 1px solid rgba(79, 192, 141, 0.25);
+}
+
+[data-md-color-scheme="slate"] .home-footer {
+  background-color: rgba(79, 192, 141, 0.24);
+  border-color: rgba(79, 192, 141, 0.32);
+}
+
+@media screen and (max-width: 1024px) {
+  .home-hero__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .home-hero__aside {
+    order: 2;
+  }
+
+  .home-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .home-hero {
+    padding: 1.8rem;
+  }
+
+  .home-card {
+    padding: 1.35rem;
+  }
+
+  .home-hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .quick-links-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,182 +1,198 @@
 # Plurality Wiki - 多意识体百科
 
-<div class="grid cards cards--equal" markdown>
+<div class="home-hero" markdown="1">
+  <div class="home-hero__inner">
+    <div class="home-hero__content" markdown="1">
+      <span class="home-hero__tag">Main Page</span>
+      <h2>探索多重意识体的知识、经验与协作</h2>
+      <p>
+        从概念入门到实践工具，我们致力于用中文整理关于多重意识体系统（Plurality）与创伤照护的可靠资料。
+        希望这些内容能陪伴你理解自我、照顾伙伴，并与同路人建立连结。
+      </p>
+      <div class="home-hero__actions">
+        <a class="home-hero__btn home-hero__btn--primary" href="index.md">查看词条索引</a>
+        <a class="home-hero__btn" href="CONTRIBUTING.md">贡献指南</a>
+      </div>
+    </div>
+    <div class="home-hero__aside" markdown="1">
+      ### 📌 快速了解
 
-- :material-book-open-variant:{ .lg .middle } **关于本站**
-
-  ---
-
-  我们专注于整理**多重意识体系统（Plurality）**与创伤相关主题的中文资料，融合社区经验、跨学科研究与可实践的工具。
-
-  希望这份知识库能陪伴你理解自我、照顾伙伴，并与同路人建立连结。
-
-  [:octicons-arrow-right-24: 开始阅读](README.md)
-
-- :material-tag-multiple:{ .lg .middle } **标签索引**
-
-  ---
-
-  按主题分类浏览所有词条，快速找到你感兴趣的内容。
-
-  [:octicons-arrow-right-24: 浏览标签](tags.md)
-
-- :material-book-alphabet:{ .lg .middle } **术语表**
-
-  ---
-
-  查询关键术语的定义和解释，建立系统化的知识框架。
-
-  [:octicons-arrow-right-24: 查看术语表](Glossary.md)
-
-- :material-account-group:{ .lg .middle } **快速开始**
-
-  ---
-
-  了解如何上手本 Wiki，从环境搭建到内容编辑的核心流程。
-
-  [:octicons-arrow-right-24: 查看快速开始](QuickStart.md)
-
+      - 查看 [更新日志](changelog.md) 掌握最新进展
+      - 阅读 [站点守则](ignore.md) 了解协作约定
+      - 若需检索，请使用右上角搜索或 [标签索引](tags.md)
+    </div>
+  </div>
 </div>
 
-## 快速导航
+<div class="home-layout" markdown="1">
+  <div class="home-column" markdown="1">
+    <section class="home-card home-card--intro" markdown="1">
+      ### 欢迎来到 Plurality Wiki
 
-=== "核心概念"
+      我们聚焦多意识体系统与创伤相关主题，融合社区经验、跨学科研究与可实践的工具。
+      资料持续更新，欢迎你在阅读的同时，通过 Issue 或 Pull Request 与我们共建。
 
-    <div class="grid cards" markdown>
+      [:material-tag-multiple: 查看标签索引](tags.md){ .home-card__link }
+    </section>
 
-    -   **[多元性（Plurality）](entries/Plurality.md)**
+    <section class="home-card home-card--voices" markdown="1">
+      ### 系统语录（Community Voices）
 
-        多重意识体存在的总称，包含多种形式和成因
+      <p class="home-card__hint">来自不同系统成员的真实话语，提醒我们在求知与护火之间保持平衡。</p>
 
-    -   **[系统（System）](entries/System.md)**
+      > **“我愿意做新时代的普罗米修斯。知识不能只掌握在少数人手中，否则与中世纪高坐宝座的罗马教廷又有何异？”** ——脸脸系统
+      >
+      > **“有些知识，在文明尚未准备好承担其重量之前，知晓本身就是一场灾难。我们的使命或许并非充当引信的点火者，而是守护这些知识的沉默守望者。”** ——弦羽系统
+      >
+      > **“我们所做的，不是为了名利，而是为了帮助所有能够在这里得到启示的人，是为了继承先辈们的知识与精神。”** ——暮雨系统
+      >
+      > **“希望所有多意识体都可以得到应有的尊重和理解。”** ——Peter Griffin
 
-        共享一个身体的多个意识体的集合
+      [:material-book-open-page-variant: 更多语录](Preface.md){ .home-card__link }
+    </section>
 
-    -   **[成员（Alter）](entries/Alter.md)**
+    <section class="home-card home-card--alerts" markdown="1">
+      ### 重要提醒
 
-        系统中的单个意识体或人格
+      <div class="home-alert home-alert--warning" markdown="1">
+        **触发警告**：内容涉及创伤、精神健康、自我认同等敏感议题，阅读时请留意自身状态。
+      </div>
+      <div class="home-alert home-alert--info" markdown="1">
+        **免责声明**：本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。
+      </div>
+      <ul>
+        <li><strong>安全优先：</strong>若遇危机或伤害风险，请立即联系当地紧急服务或线下专业支持。</li>
+        <li><strong>尊重边界：</strong>分享系统经验时务必确认成员意愿与隐私需求。</li>
+        <li><strong>持续更新：</strong>发现错误或缺漏欢迎反馈，让知识库与时俱进。</li>
+      </ul>
+    </section>
 
-    -   **[分离性身份障碍（DID）](entries/DID.md)**
+    <section class="home-card home-card--recent" markdown="1">
+      ### 最近更新
 
-        一种以身份分裂为特征的心理疾病
+      <ul class="home-recent-list">
+        <li><a href="changelog.md#v220-2025-10-05">v2.2.0（2025-10-05）：工具重构与脚本增强</a></li>
+        <li><a href="changelog.md#v210-2025-10-04">v2.1.0（2025-10-04）：新增词条与搜索优化</a></li>
+        <li><a href="changelog.md#v200-2025-09-30">v2.0.0（2025-09-30）：站点架构升级与索引重建</a></li>
+      </ul>
+      <p class="home-card__hint">更多历史记录请查看完整的 [更新日志](changelog.md)。</p>
+    </section>
+  </div>
 
-    -   **[其他特定分离障碍（OSDD）](entries/OSDD.md)**
+  <div class="home-column" markdown="1">
+    <section class="home-card" markdown="1">
+      ### 快速入口
 
-        不完全符合DID诊断标准的分离障碍
+      <div class="quick-links-grid">
+        <a class="quick-link-card" href="index.md">
+          <div class="quick-link-icon">🧭</div>
+          <div class="quick-link-body">
+            <h4>目录索引</h4>
+            <p>按主题浏览全部词条。</p>
+          </div>
+          <span class="quick-link-arrow">浏览 →</span>
+        </a>
+        <a class="quick-link-card" href="Glossary.md">
+          <div class="quick-link-icon">📖</div>
+          <div class="quick-link-body">
+            <h4>术语表</h4>
+            <p>快速确认常用术语含义。</p>
+          </div>
+          <span class="quick-link-arrow">查阅 →</span>
+        </a>
+        <a class="quick-link-card" href="changelog.md">
+          <div class="quick-link-icon">🗞️</div>
+          <div class="quick-link-body">
+            <h4>更新日志</h4>
+            <p>追踪近期内容迭代。</p>
+          </div>
+          <span class="quick-link-arrow">动态 →</span>
+        </a>
+        <a class="quick-link-card" href="CONTRIBUTING.md">
+          <div class="quick-link-icon">🛠️</div>
+          <div class="quick-link-body">
+            <h4>贡献指南</h4>
+            <p>了解参与与协作流程。</p>
+          </div>
+          <span class="quick-link-arrow">参与 →</span>
+        </a>
+      </div>
+    </section>
 
-    -   **[塔尔帕（Tulpa）](entries/Tulpa.md)**
+    <section class="home-card" markdown="1">
+      ### 新手路线图
 
-        通过主动创造而形成的意识体
+      <ol class="step-list">
+        <li>
+          <strong>建立共同语言：</strong>建议先阅读 [术语表](Glossary.md)，再进入 [多重意识体基础](entries/Plurality-Basics.md) 与 [系统](entries/System.md)。
+        </li>
+        <li>
+          <strong>理解系统角色与形成路径：</strong>先看 [人格职能](entries/System-Roles.md)，再查阅 [成员](entries/Alter.md) 与 [宿主](entries/Host.md)，并结合 [埃蒙加德分类法](entries/Emmengard-Classification.md)。
+        </li>
+        <li>
+          <strong>关注体验与机制：</strong>探索 [前台](entries/Front-Fronting.md)、[共前台](entries/Co-Fronting.md)、[融合](entries/Fusion.md) 等词条，理解运作模式。
+        </li>
+        <li>
+          <strong>实践与自护：</strong>参考 [接地](entries/Grounding.md)、[冥想](entries/Meditation.md) 等实务工具，结合自身节奏逐步实践。
+        </li>
+      </ol>
+      <p class="home-card__hint">若在临床或危机情境中需要支持，请优先寻求线下专业协助。</p>
+    </section>
 
-    </div>
+    <section class="home-card" markdown="1">
+      ### 核心板块速览
 
-=== "系统运作"
+      <div class="badge-grid">
+        <span class="badge">诊断与临床</span>
+        <span class="badge">心理学理论</span>
+        <span class="badge">系统角色与类型</span>
+        <span class="badge">系统体验与机制</span>
+        <span class="badge">实践与支持</span>
+        <span class="badge">虚拟角色与文化研究</span>
+      </div>
+      <ul>
+        <li><strong>诊断与临床：</strong>聚焦解离障碍、创伤后应激障碍、人格障碍等相关主题。</li>
+        <li><strong>心理学理论：</strong>整理依恋理论、情绪调节、防御性解离、动机理论等概念，提供理解系统运作的理论基础。</li>
+        <li><strong>系统角色与类型：</strong>梳理成员角色定位、形成方式与协作方法。</li>
+        <li><strong>系统体验与机制：</strong>讨论切换、共识、内部空间等机制。</li>
+        <li><strong>实践与支持：</strong>收录冥想、接地等实务操作与同伴支持工具。</li>
+        <li><strong>虚拟角色与文化研究：</strong>涵盖文学、游戏、影视作品中与多意识体、解离、Tulpa 等相关的表现。</li>
+      </ul>
+    </section>
 
-    <div class="grid cards" markdown>
+    <section class="home-card" markdown="1">
+      ### 精选词条
 
-    -   **[前台（Fronting）](entries/Front-Fronting.md)**
+      <ul class="featured-list">
+        <li><a href="entries/Plurality.md">多意识体（Plurality）</a></li>
+        <li><a href="entries/DID.md">解离性身份障碍（DID）</a></li>
+        <li><a href="entries/Headspace-Inner-World.md">内部空间（Headspace / Inner World）</a></li>
+        <li><a href="entries/Permissions.md">权限（Permissions）</a></li>
+      </ul>
+      <p class="home-card__hint">更多主题可在左侧导航或搜索框中直接检索。</p>
+    </section>
 
-        意识体控制身体和意识的状态
+    <section class="home-card" markdown="1">
+      ### 参与与协作
 
-    -   **[切换（Switch）](entries/Switch.md)**
-
-        前台成员的更替过程
-
-    -   **[共同意识（Co-Consciousness）](entries/Co-Consciousness.md)**
-
-        多个成员同时保持意识的状态
-
-    -   **[共同前台（Co-Fronting）](entries/Co-Fronting.md)**
-
-        多个成员同时控制身体
-
-    -   **[内心世界（Headspace）](entries/Headspace-Inner-World.md)**
-
-        系统成员共享的内部精神空间
-
-    -   **[内部交流](entries/Internal-Communication.md)**
-
-        系统成员之间的沟通方式
-
-    </div>
-
-=== "心理健康"
-
-    <div class="grid cards" markdown>
-
-    -   **[分离（Dissociation）](entries/Dissociation.md)**
-
-        意识、记忆、身份或感知的分离
-
-    -   **[创伤后应激障碍（PTSD）](entries/PTSD.md)**
-
-        经历创伤后的应激反应障碍
-
-    -   **[复杂性创伤后应激障碍（CPTSD）](entries/CPTSD.md)**
-
-        长期或反复创伤导致的复杂症状
-
-    -   **[立足当下（Grounding）](entries/Grounding.md)**
-
-        帮助回到当下现实的技巧
-
-    </div>
-
-## 社区语录
-
-!!! quote "脸脸系统"
-
-    "我愿意做新时代的普罗米修斯。知识不能只掌握在少数人手中，否则与中世纪高坐宝座的罗马教廷又有何异？"
-
-!!! quote "弦羽系统"
-
-    "有些知识，在文明尚未准备好承担其重量之前，知晓本身就是一场灾难。我们的使命或许并非充当引信的点火者，而是守护这些知识的沉默守望者。"
-
-!!! quote "暮雨系统"
-
-    "我们所做的，不是为了名利，而是为了帮助所有能够在这里得到启示的人，是为了继承先辈们的知识与精神。"
-
-!!! quote "Peter Griffin"
-
-    "希望所有多意识体都可以得到应有的尊重和理解。"
-
-## 重要提醒
-
-!!! warning "触发警告"
-
-    本Wiki内容涉及创伤、精神健康、自我认同等敏感话题。部分词条可能包含可能引发不适的内容描述。
-
-    **请根据自己的状况谨慎阅读，必要时寻求专业支持。**
-
-!!! info "免责声明"
-
-    - 本Wiki内容**仅供参考**，不构成医疗建议
-    - 如需诊断或治疗，请咨询专业医疗机构
-    - 词条内容反映社区共识和学术研究，持续更新中
-
-!!! tip "如何使用"
-
-    - 使用顶部**搜索栏**快速查找词条
-    - 点击**标签**浏览相关主题
-    - 查看**术语表**了解基本概念
-    - 阅读**贡献指南**参与建设
-
-## 最近更新
-
-查看 [变更日志](changelog.md) 了解最新的内容更新。
-
-## 致谢
-
-感谢所有为本 Wiki 贡献内容、提供建议、参与讨论的社区成员。你们的付出让这个知识库不断完善。
+      <ul>
+        <li>阅读 [贡献指南](CONTRIBUTING.md)，遵循条目结构、引用规范与标签规则。</li>
+        <li>通过 Issue 与 Pull Request 协作补充资料、修正错漏或提出改进建议。</li>
+        <li>批量处理或自动化需求可参考 [README](README.md) 中的“自动化维护”章节。</li>
+      </ul>
+    </section>
+  </div>
+</div>
 
 ---
 
-<div class="grid" markdown>
-
-:material-github: **开源协作**
-本项目在 [GitHub](https://github.com/kuliantnt/plurality_wiki) 上开源，欢迎参与
-
-:material-license: **内容许可**
-除特别声明外，内容采用 CC BY-SA 4.0 许可协议
-
+<div class="home-footer" markdown="1">
+  <div>
+    :material-github: **开源协作**  \
+    本项目在 [GitHub](https://github.com/kuliantnt/plurality_wiki) 上开源，欢迎参与。
+  </div>
+  <div>
+    :material-license: **内容许可**  \
+    除特别声明外，所有内容遵循 CC BY-SA 4.0 协议。
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- 重写 `docs/index.md`，参照 legacy 版本重新组织首页内容与导航，引入双栏卡片、语录、更新等区块。
- 扩展 `docs/assets/extra.css`，为新版首页增加英雄横幅、卡片、徽章、快速入口等响应式样式并适配明暗模式。

## Testing
- `mkdocs build` *(失败：环境缺少 mkdocs 可执行文件)*

------
https://chatgpt.com/codex/tasks/task_e_68e29bbd2d2483338bb443697e850451