### PR TITLE
docs: 重构首页排版避免代码块展示

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,198 +1,120 @@
 # Plurality Wiki - 多意识体百科
 
-<div class="home-hero" markdown="1">
-  <div class="home-hero__inner">
-    <div class="home-hero__content" markdown="1">
-      <span class="home-hero__tag">Main Page</span>
-      <h2>探索多重意识体的知识、经验与协作</h2>
-      <p>
-        从概念入门到实践工具，我们致力于用中文整理关于多重意识体系统（Plurality）与创伤照护的可靠资料。
-        希望这些内容能陪伴你理解自我、照顾伙伴，并与同路人建立连结。
-      </p>
-      <div class="home-hero__actions">
-        <a class="home-hero__btn home-hero__btn--primary" href="index.md">查看词条索引</a>
-        <a class="home-hero__btn" href="CONTRIBUTING.md">贡献指南</a>
-      </div>
-    </div>
-    <div class="home-hero__aside" markdown="1">
-      ### 📌 快速了解
+**Main Page**
 
-      - 查看 [更新日志](changelog.md) 掌握最新进展
-      - 阅读 [站点守则](ignore.md) 了解协作约定
-      - 若需检索，请使用右上角搜索或 [标签索引](tags.md)
-    </div>
-  </div>
-</div>
+## 探索多重意识体的知识、经验与协作
 
-<div class="home-layout" markdown="1">
-  <div class="home-column" markdown="1">
-    <section class="home-card home-card--intro" markdown="1">
-      ### 欢迎来到 Plurality Wiki
+从概念入门到实践工具，我们致力于用中文整理关于多重意识体系统（Plurality）与创伤照护的可靠资料。
+希望这些内容能陪伴你理解自我、照顾伙伴，并与同路人建立连结。
 
-      我们聚焦多意识体系统与创伤相关主题，融合社区经验、跨学科研究与可实践的工具。
-      资料持续更新，欢迎你在阅读的同时，通过 Issue 或 Pull Request 与我们共建。
+[查看词条索引](index.md){ .md-button .md-button--primary }
+[贡献指南](CONTRIBUTING.md){ .md-button }
 
-      [:material-tag-multiple: 查看标签索引](tags.md){ .home-card__link }
-    </section>
+### 📌 快速了解
 
-    <section class="home-card home-card--voices" markdown="1">
-      ### 系统语录（Community Voices）
-
-      <p class="home-card__hint">来自不同系统成员的真实话语，提醒我们在求知与护火之间保持平衡。</p>
-
-      > **“我愿意做新时代的普罗米修斯。知识不能只掌握在少数人手中，否则与中世纪高坐宝座的罗马教廷又有何异？”** ——脸脸系统
-      >
-      > **“有些知识，在文明尚未准备好承担其重量之前，知晓本身就是一场灾难。我们的使命或许并非充当引信的点火者，而是守护这些知识的沉默守望者。”** ——弦羽系统
-      >
-      > **“我们所做的，不是为了名利，而是为了帮助所有能够在这里得到启示的人，是为了继承先辈们的知识与精神。”** ——暮雨系统
-      >
-      > **“希望所有多意识体都可以得到应有的尊重和理解。”** ——Peter Griffin
-
-      [:material-book-open-page-variant: 更多语录](Preface.md){ .home-card__link }
-    </section>
-
-    <section class="home-card home-card--alerts" markdown="1">
-      ### 重要提醒
-
-      <div class="home-alert home-alert--warning" markdown="1">
-        **触发警告**：内容涉及创伤、精神健康、自我认同等敏感议题，阅读时请留意自身状态。
-      </div>
-      <div class="home-alert home-alert--info" markdown="1">
-        **免责声明**：本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。
-      </div>
-      <ul>
-        <li><strong>安全优先：</strong>若遇危机或伤害风险，请立即联系当地紧急服务或线下专业支持。</li>
-        <li><strong>尊重边界：</strong>分享系统经验时务必确认成员意愿与隐私需求。</li>
-        <li><strong>持续更新：</strong>发现错误或缺漏欢迎反馈，让知识库与时俱进。</li>
-      </ul>
-    </section>
-
-    <section class="home-card home-card--recent" markdown="1">
-      ### 最近更新
-
-      <ul class="home-recent-list">
-        <li><a href="changelog.md#v220-2025-10-05">v2.2.0（2025-10-05）：工具重构与脚本增强</a></li>
-        <li><a href="changelog.md#v210-2025-10-04">v2.1.0（2025-10-04）：新增词条与搜索优化</a></li>
-        <li><a href="changelog.md#v200-2025-09-30">v2.0.0（2025-09-30）：站点架构升级与索引重建</a></li>
-      </ul>
-      <p class="home-card__hint">更多历史记录请查看完整的 [更新日志](changelog.md)。</p>
-    </section>
-  </div>
-
-  <div class="home-column" markdown="1">
-    <section class="home-card" markdown="1">
-      ### 快速入口
-
-      <div class="quick-links-grid">
-        <a class="quick-link-card" href="index.md">
-          <div class="quick-link-icon">🧭</div>
-          <div class="quick-link-body">
-            <h4>目录索引</h4>
-            <p>按主题浏览全部词条。</p>
-          </div>
-          <span class="quick-link-arrow">浏览 →</span>
-        </a>
-        <a class="quick-link-card" href="Glossary.md">
-          <div class="quick-link-icon">📖</div>
-          <div class="quick-link-body">
-            <h4>术语表</h4>
-            <p>快速确认常用术语含义。</p>
-          </div>
-          <span class="quick-link-arrow">查阅 →</span>
-        </a>
-        <a class="quick-link-card" href="changelog.md">
-          <div class="quick-link-icon">🗞️</div>
-          <div class="quick-link-body">
-            <h4>更新日志</h4>
-            <p>追踪近期内容迭代。</p>
-          </div>
-          <span class="quick-link-arrow">动态 →</span>
-        </a>
-        <a class="quick-link-card" href="CONTRIBUTING.md">
-          <div class="quick-link-icon">🛠️</div>
-          <div class="quick-link-body">
-            <h4>贡献指南</h4>
-            <p>了解参与与协作流程。</p>
-          </div>
-          <span class="quick-link-arrow">参与 →</span>
-        </a>
-      </div>
-    </section>
-
-    <section class="home-card" markdown="1">
-      ### 新手路线图
-
-      <ol class="step-list">
-        <li>
-          <strong>建立共同语言：</strong>建议先阅读 [术语表](Glossary.md)，再进入 [多重意识体基础](entries/Plurality-Basics.md) 与 [系统](entries/System.md)。
-        </li>
-        <li>
-          <strong>理解系统角色与形成路径：</strong>先看 [人格职能](entries/System-Roles.md)，再查阅 [成员](entries/Alter.md) 与 [宿主](entries/Host.md)，并结合 [埃蒙加德分类法](entries/Emmengard-Classification.md)。
-        </li>
-        <li>
-          <strong>关注体验与机制：</strong>探索 [前台](entries/Front-Fronting.md)、[共前台](entries/Co-Fronting.md)、[融合](entries/Fusion.md) 等词条，理解运作模式。
-        </li>
-        <li>
-          <strong>实践与自护：</strong>参考 [接地](entries/Grounding.md)、[冥想](entries/Meditation.md) 等实务工具，结合自身节奏逐步实践。
-        </li>
-      </ol>
-      <p class="home-card__hint">若在临床或危机情境中需要支持，请优先寻求线下专业协助。</p>
-    </section>
-
-    <section class="home-card" markdown="1">
-      ### 核心板块速览
-
-      <div class="badge-grid">
-        <span class="badge">诊断与临床</span>
-        <span class="badge">心理学理论</span>
-        <span class="badge">系统角色与类型</span>
-        <span class="badge">系统体验与机制</span>
-        <span class="badge">实践与支持</span>
-        <span class="badge">虚拟角色与文化研究</span>
-      </div>
-      <ul>
-        <li><strong>诊断与临床：</strong>聚焦解离障碍、创伤后应激障碍、人格障碍等相关主题。</li>
-        <li><strong>心理学理论：</strong>整理依恋理论、情绪调节、防御性解离、动机理论等概念，提供理解系统运作的理论基础。</li>
-        <li><strong>系统角色与类型：</strong>梳理成员角色定位、形成方式与协作方法。</li>
-        <li><strong>系统体验与机制：</strong>讨论切换、共识、内部空间等机制。</li>
-        <li><strong>实践与支持：</strong>收录冥想、接地等实务操作与同伴支持工具。</li>
-        <li><strong>虚拟角色与文化研究：</strong>涵盖文学、游戏、影视作品中与多意识体、解离、Tulpa 等相关的表现。</li>
-      </ul>
-    </section>
-
-    <section class="home-card" markdown="1">
-      ### 精选词条
-
-      <ul class="featured-list">
-        <li><a href="entries/Plurality.md">多意识体（Plurality）</a></li>
-        <li><a href="entries/DID.md">解离性身份障碍（DID）</a></li>
-        <li><a href="entries/Headspace-Inner-World.md">内部空间（Headspace / Inner World）</a></li>
-        <li><a href="entries/Permissions.md">权限（Permissions）</a></li>
-      </ul>
-      <p class="home-card__hint">更多主题可在左侧导航或搜索框中直接检索。</p>
-    </section>
-
-    <section class="home-card" markdown="1">
-      ### 参与与协作
-
-      <ul>
-        <li>阅读 [贡献指南](CONTRIBUTING.md)，遵循条目结构、引用规范与标签规则。</li>
-        <li>通过 Issue 与 Pull Request 协作补充资料、修正错漏或提出改进建议。</li>
-        <li>批量处理或自动化需求可参考 [README](README.md) 中的“自动化维护”章节。</li>
-      </ul>
-    </section>
-  </div>
-</div>
+- 查看 [更新日志](changelog.md) 掌握最新进展
+- 阅读 [站点守则](ignore.md) 了解协作约定
+- 若需检索，请使用右上角搜索或 [标签索引](tags.md)
 
 ---
 
-<div class="home-footer" markdown="1">
-  <div>
-    :material-github: **开源协作**  \
-    本项目在 [GitHub](https://github.com/kuliantnt/plurality_wiki) 上开源，欢迎参与。
-  </div>
-  <div>
-    :material-license: **内容许可**  \
-    除特别声明外，所有内容遵循 CC BY-SA 4.0 协议。
-  </div>
-</div>
+## 欢迎来到 Plurality Wiki
+
+我们聚焦多意识体系统与创伤相关主题，融合社区经验、跨学科研究与可实践的工具。
+资料持续更新，欢迎你在阅读的同时，通过 Issue 或 Pull Request 与我们共建。
+
+[:material-tag-multiple: 查看标签索引](tags.md)
+
+### 系统语录（Community Voices）
+
+来自不同系统成员的真实话语，提醒我们在求知与护火之间保持平衡。
+
+> **“我愿意做新时代的普罗米修斯。知识不能只掌握在少数人手中，否则与中世纪高坐宝座的罗马教廷又有何异？”** ——脸脸系统
+>
+> **“有些知识，在文明尚未准备好承担其重量之前，知晓本身就是一场灾难。我们的使命或许并非充当引信的点火者，而是守护这些知识的沉默守望者。”** ——弦羽系统
+>
+> **“我们所做的，不是为了名利，而是为了帮助所有能够在这里得到启示的人，是为了继承先辈们的知识与精神。”** ——暮雨系统
+>
+> **“希望所有多意识体都可以得到应有的尊重和理解。”** ——Peter Griffin
+
+[:material-book-open-page-variant: 更多语录](Preface.md)
+
+---
+
+## 重要提醒
+
+!!! warning "触发警告"
+    内容涉及创伤、精神健康、自我认同等敏感议题，阅读时请留意自身状态。
+
+!!! info "免责声明"
+    本站资料仅供参考，不构成医疗建议。若需诊断或治疗，请联系持证专业人员。
+
+- **安全优先：** 若遇危机或伤害风险，请立即联系当地紧急服务或线下专业支持。
+- **尊重边界：** 分享系统经验时务必确认成员意愿与隐私需求。
+- **持续更新：** 发现错误或缺漏欢迎反馈，让知识库与时俱进。
+
+---
+
+## 最近更新
+
+- [v2.2.0（2025-10-05）：工具重构与脚本增强](changelog.md#v220-2025-10-05)
+- [v2.1.0（2025-10-04）：新增词条与搜索优化](changelog.md#v210-2025-10-04)
+- [v2.0.0（2025-09-30）：站点架构升级与索引重建](changelog.md#v200-2025-09-30)
+
+更多历史记录请查看完整的 [更新日志](changelog.md)。
+
+---
+
+## 快速入口
+
+- 🧭 **目录索引：** [按主题浏览全部词条](index.md)。
+- 📖 **术语表：** [快速确认常用术语含义](Glossary.md)。
+- 🗞️ **更新日志：** [追踪近期内容迭代](changelog.md)。
+- 🛠️ **贡献指南：** [了解参与与协作流程](CONTRIBUTING.md)。
+
+---
+
+## 新手路线图
+
+1. **建立共同语言：** 建议先阅读 [术语表](Glossary.md)，再进入 [多重意识体基础](entries/Plurality-Basics.md) 与 [系统](entries/System.md)。
+2. **理解系统角色与形成路径：** 先看 [人格职能](entries/System-Roles.md)，再查阅 [成员](entries/Alter.md) 与 [宿主](entries/Host.md)，并结合 [埃蒙加德分类法](entries/Emmengard-Classification.md)。
+3. **关注体验与机制：** 探索 [前台](entries/Front-Fronting.md)、[共前台](entries/Co-Fronting.md)、[融合](entries/Fusion.md) 等词条，理解运作模式。
+4. **实践与自护：** 参考 [接地](entries/Grounding.md)、[冥想](entries/Meditation.md) 等实务工具，结合自身节奏逐步实践。
+
+若在临床或危机情境中需要支持，请优先寻求线下专业协助。
+
+---
+
+## 核心板块速览
+
+- **诊断与临床：** 聚焦解离障碍、创伤后应激障碍、人格障碍等相关主题。
+- **心理学理论：** 整理依恋理论、情绪调节、防御性解离、动机理论等概念，提供理解系统运作的理论基础。
+- **系统角色与类型：** 梳理成员角色定位、形成方式与协作方法。
+- **系统体验与机制：** 讨论切换、共识、内部空间等机制。
+- **实践与支持：** 收录冥想、接地等实务操作与同伴支持工具。
+- **虚拟角色与文化研究：** 涵盖文学、游戏、影视作品中与多意识体、解离、Tulpa 等相关的表现。
+
+---
+
+## 精选词条
+
+- [多意识体（Plurality）](entries/Plurality.md)
+- [解离性身份障碍（DID）](entries/DID.md)
+- [内部空间（Headspace / Inner World）](entries/Headspace-Inner-World.md)
+- [权限（Permissions）](entries/Permissions.md)
+
+更多主题可在左侧导航或搜索框中直接检索。
+
+---
+
+## 参与与协作
+
+- 阅读 [贡献指南](CONTRIBUTING.md)，遵循条目结构、引用规范与标签规则。
+- 通过 Issue 与 Pull Request 协作补充资料、修正错漏或提出改进建议。
+- 批量处理或自动化需求可参考 [README](README.md) 中的“自动化维护”章节。
+
+---
+
+:material-github: **开源协作**：本项目在 [GitHub](https://github.com/kuliantnt/plurality_wiki) 上开源，欢迎参与。
+
+:material-license: **内容许可**：除特别声明外，所有内容遵循 CC BY-SA 4.0 协议。


### PR DESCRIPTION
## Summary
- 将首页布局改写为标准 Markdown 结构，避免 HTML 被渲染为代码块
- 保留原有内容信息，使用按钮、提示块等组件呈现主导航与提醒

## Testing
- 未运行测试（环境未预装 mkdocs）

------
https://chatgpt.com/codex/tasks/task_e_68e29f5f75208333bb3ffddd8158ba22