### PR TITLE
重构系统运作导览与导航

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,10 +41,10 @@
 
 ### 系统运作
 
-- 前台（Fronting）与切换（Switch）
-- 共同意识与共同前台
-- 内心世界（Headspace）
-- 内部交流机制
+- **[系统运作导览](System-Operations.md)**：提供专题导航，串联前台、记忆协作与治理结构等重点文章。
+- **前台与切换**：从 [前台（Fronting）](entries/Front-Fronting.md)、[切换（Switch）](entries/Switch.md) 到 [共同前台（Co-Fronting）](entries/Co-Fronting.md)，理解成员如何交接与协作。
+- **意识共享与记忆管理**：结合 [共同意识](entries/Co-Consciousness.md)、[记忆持有人](entries/Memory-Holder.md)、[记忆屏障](entries/Memory-Shielding.md) 等词条，探索信息流动与安全策略。
+- **内部空间与协作机制**：阅读 [内心世界](entries/Headspace-Inner-World.md)、[内部交流](entries/Internal-Communication.md)、[系统角色](entries/System-Roles.md)、[管理者](entries/Admin.md)、[守门人](entries/Gatekeeper.md)、[保护者](entries/Protector.md) 与 [权限](entries/Permissions.md)，建立治理框架。
 
 ### 心理健康
 

--- a/docs/System-Operations.md
+++ b/docs/System-Operations.md
@@ -1,0 +1,48 @@
+# 系统运作导览
+
+多意识体系统的运作不仅关乎谁在前台，更涉及成员之间如何分享信息、维护边界与协同完成日常任务。本导览汇整核心机制，并串联相关词条，帮助你在不同主题之间快速跳转。
+
+## 前台与切换节奏
+
+系统在日常生活中往往需要灵活调整由谁负责前台。了解不同的前台模式与切换方式，有助于成员之间建立共识、减少混乱。
+
+- [前台（Fronting）](entries/Front-Fronting.md)：解释前台的定义、常见感受与可能的困难。
+- [切换（Switch）](entries/Switch.md)：介绍前台更替的触发情境、支持策略与安全注意事项。
+- [共同前台（Co-Fronting）](entries/Co-Fronting.md)：讨论成员如何在同一时间共同控制身体或分享执行任务。
+
+## 意识共享与记忆管理
+
+不同成员对事件的记忆与感知常常不一致。学习如何共享、保护或隔离记忆，可以让系统在安全与透明之间取得平衡。
+
+- [共同意识（Co-Consciousness）](entries/Co-Consciousness.md)：说明保持同时觉察的好处、挑战与训练方法。
+- [记忆持有人（Memory Holder）](entries/Memory-Holder.md)：整理负责储存特定记忆的角色与协作模式。
+- [记忆屏障（Memory Shielding）](entries/Memory-Shielding.md)：解析为了安全而建立的记忆隔离及其潜在影响。
+
+## 内部空间与沟通网络
+
+内部世界为成员提供了互动与处理情绪的场所，而高效的沟通则是维持秩序的关键。善用这些资源能让系统在面对压力时更有弹性。
+
+- [内心世界（Headspace / Inner World）](entries/Headspace-Inner-World.md)：描述内部空间的常见结构与调整方式。
+- [内部交流（Internal Communication）](entries/Internal-Communication.md)：提供建立沟通渠道、记录机制与冲突调解的实务建议。
+- [权限（Permissions）](entries/Permissions.md)：说明系统如何设置访问、前台或决策的权限管理。
+
+## 角色协作与治理结构
+
+明确的角色分工能够提升安全感，避免成员在面对危机时手忙脚乱。透过了解常见角色与治理模式，可以为系统制定更贴合的协作策略。
+
+- [系统角色（System Roles）](entries/System-Roles.md)：总览常见的职能分类与评估方法。
+- [管理者（Admin）](entries/Admin.md) 与 [宿主（Host）](entries/Host.md)：比较日常管理与外部沟通的不同职责。
+- [守门人（Gatekeeper）](entries/Gatekeeper.md) 与 [保护者（Protector）](entries/Protector.md)：探讨边界维护、危机应对与内部安全。
+- [内部自助者（Internal Self Helper, ISH）](entries/Internal-Self-Helper-ISH.md)：了解提供内部指导与调解的特殊角色。
+
+## 实务支持与自我照顾
+
+系统运作离不开稳定的生活节奏与自护工具。从感官调节到照护角色的协作，以下词条能帮助你将理论落实到日常实践。
+
+- [立足当下（Grounding）](entries/Grounding.md)：收录常见的感官调节技巧，协助前台稳定状态。
+- [照护者（Caregiver）](entries/Caregiver.md)：讨论照顾其他成员时的注意事项与资源配置。
+- [心理创伤与危机应对](entries/Trauma.md)：整理创伤反应的基本知识，提示何时需要专业协助。
+
+---
+
+想快速浏览其他主题？可以搭配 [核心概念](entries/Plurality.md) 与 [心理健康](entries/Dissociation.md) 等板块，一起构建更完整的知识地图。

--- a/docs/index-material.md
+++ b/docs/index-material.md
@@ -74,29 +74,21 @@
 
     <div class="grid cards" markdown>
 
-    -   **[前台（Fronting）](entries/Front-Fronting.md)**
+    -   **[系统运作导览](System-Operations.md)**
 
-        意识体控制身体和意识的状态
+        梳理前台、意识共享、角色协作等关键主题，快速定位延伸阅读词条。
 
-    -   **[切换（Switch）](entries/Switch.md)**
+    -   **前台与切换流程**
 
-        前台成员的更替过程
+        聚焦 [前台（Fronting）](entries/Front-Fronting.md)、[切换（Switch）](entries/Switch.md) 与 [共同前台（Co-Fronting）](entries/Co-Fronting.md)，理解成员如何协同掌控身体。
 
-    -   **[共同意识（Co-Consciousness）](entries/Co-Consciousness.md)**
+    -   **意识共享与记忆管理**
 
-        多个成员同时保持意识的状态
+        延伸至 [共同意识](entries/Co-Consciousness.md)、[记忆持有人](entries/Memory-Holder.md)、[记忆屏障](entries/Memory-Shielding.md) 等词条，探索信息传递与防护策略。
 
-    -   **[共同前台（Co-Fronting）](entries/Co-Fronting.md)**
+    -   **内部空间与治理结构**
 
-        多个成员同时控制身体
-
-    -   **[内心世界（Headspace）](entries/Headspace-Inner-World.md)**
-
-        系统成员共享的内部精神空间
-
-    -   **[内部交流](entries/Internal-Communication.md)**
-
-        系统成员之间的沟通方式
+        结合 [内心世界](entries/Headspace-Inner-World.md)、[内部交流](entries/Internal-Communication.md)、[系统角色](entries/System-Roles.md)、[管理者](entries/Admin.md)、[守门人](entries/Gatekeeper.md)、[保护者](entries/Protector.md) 与 [权限](entries/Permissions.md) 的资料，建立协作框架。
 
     </div>
 

--- a/docs/index-simple.md
+++ b/docs/index-simple.md
@@ -28,12 +28,20 @@
 
 ## 系统运作
 
-- **[前台（Fronting）](entries/Front-Fronting.md)** - 意识体控制身体和意识的状态
-- **[切换（Switch）](entries/Switch.md)** - 前台成员的更替过程
-- **[共同意识（Co-Consciousness）](entries/Co-Consciousness.md)** - 多个成员同时保持意识的状态
-- **[共同前台（Co-Fronting）](entries/Co-Fronting.md)** - 多个成员同时控制身体
-- **[内心世界（Headspace）](entries/Headspace-Inner-World.md)** - 系统成员共享的内部精神空间
-- **[内部交流](entries/Internal-Communication.md)** - 系统成员之间的沟通方式
+- **[系统运作导览](System-Operations.md)** - 总览前台、记忆协作与角色治理，作为专题索引入口。
+- **前台与切换流程**
+    - [前台（Fronting）](entries/Front-Fronting.md) - 说明谁在掌控身体以及常见感受。
+    - [切换（Switch）](entries/Switch.md) - 描述前台更替的触发情境与应对技巧。
+    - [共同前台（Co-Fronting）](entries/Co-Fronting.md) - 展示多名成员协同执行任务的方式。
+- **意识共享与记忆管理**
+    - [共同意识（Co-Consciousness）](entries/Co-Consciousness.md) - 探讨同时保持觉察的好处与挑战。
+    - [记忆持有人（Memory Holder）](entries/Memory-Holder.md) - 说明专责保存记忆的角色运作模式。
+    - [记忆屏障（Memory Shielding）](entries/Memory-Shielding.md) - 分析记忆隔离的安全意义与代价。
+- **内部空间与治理结构**
+    - [内心世界（Headspace）](entries/Headspace-Inner-World.md) - 描述内部世界的构成与调整方法。
+    - [内部交流](entries/Internal-Communication.md) - 汇整建立沟通渠道的实践经验。
+    - [系统角色](entries/System-Roles.md) / [管理者](entries/Admin.md) / [守门人](entries/Gatekeeper.md) / [保护者](entries/Protector.md) - 对照常见角色的职责与协作重点。
+    - [权限（Permissions）](entries/Permissions.md) 与 [内部自助者（ISH）](entries/Internal-Self-Helper-ISH.md) - 辅助建立治理规则与内部支持系统。
 
 ## 心理健康
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,12 +242,26 @@ nav:
     - entries/OSDD.md
     - entries/Tulpa.md
   - 系统运作:
-    - entries/Front-Fronting.md
-    - entries/Switch.md
-    - entries/Co-Consciousness.md
-    - entries/Co-Fronting.md
-    - entries/Headspace-Inner-World.md
-    - entries/Internal-Communication.md
+    - 系统运作导览: System-Operations.md
+    - 前台与切换:
+        - entries/Front-Fronting.md
+        - entries/Switch.md
+        - entries/Co-Fronting.md
+    - 意识共享与记忆:
+        - entries/Co-Consciousness.md
+        - entries/Memory-Holder.md
+        - entries/Memory-Shielding.md
+    - 内部空间与沟通:
+        - entries/Headspace-Inner-World.md
+        - entries/Internal-Communication.md
+        - entries/Permissions.md
+    - 角色与治理:
+        - entries/System-Roles.md
+        - entries/Admin.md
+        - entries/Host.md
+        - entries/Gatekeeper.md
+        - entries/Protector.md
+        - entries/Internal-Self-Helper-ISH.md
   - 心理健康:
     - entries/Dissociation.md
     - entries/PTSD.md


### PR DESCRIPTION
## Summary
- 新增系統運作導覽專題頁，串聯前台、記憶與治理相關詞條
- 調整首頁（Material 與簡潔版）中的系統運作區塊，提供分組說明與延伸閱讀
- 重構 MkDocs 導航中的「系統運作」層級，補充角色與記憶管理等既有詞條入口

## Testing
- mkdocs build --strict *(missing: mkdocs 未安裝於執行環境)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aebfe9408333a7b1b3f9b18d8c5f