### PR TITLE
修复 PDF 导出目录符号与跳转

### DIFF
--- a/tools/pdf_export/pdf_export/markdown.py
+++ b/tools/pdf_export/pdf_export/markdown.py
@@ -298,8 +298,8 @@ def build_directory_page(
             )
             entry_title = escape_latex(document.title)
             lines.append(
-                rf"\noindent\hspace{{1em}}\textbullet\;"
-                rf"\hyperlink{{{anchor}}}{{{entry_title}}}"
+                rf"\noindent\hspace{{1em}}\textbullet\hspace{{0.6em}}"
+                rf"\hyperref[{anchor}]{{{entry_title}}}"
                 rf"\nobreak\dotfill\pageref{{{anchor}}}\par"
             )
 


### PR DESCRIPTION
## 摘要
- 调整 PDF 导出目录的前缀格式，替换数学模式空格命令，避免条目前出现 `‧;`。
- 改用 `\hyperref` 指令生成目录链接，确保点击标题可跳转到对应条目。

## 测试
- python -m compileall tools/pdf_export/pdf_export/markdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e30cad18808333913b23c53c82eadb