### PR TITLE
fix: 修复标签示例干扰标签导航

### DIFF
--- a/docs/dev/CLEANUP_RECOMMENDATIONS.md
+++ b/docs/dev/CLEANUP_RECOMMENDATIONS.md
@@ -49,7 +49,7 @@ mkdocs build && python -m http.server -d site/ 8080
 **删除理由**：
 - MkDocs Material 的 `tags` 插件自动生成标签页面
 - 当前 `docs/tags.md` 已改为手动维护的导览页 + 自动标签列表
-- 使用 `<!-- material/tags -->` 注释自动插入标签
+- 使用 `&lt;!-- material/tags --&gt;` 注释自动插入标签
 
 **当前 tags.md 结构**：
 ```markdown
@@ -63,7 +63,7 @@ mkdocs build && python -m http.server -d site/ 8080
 ...
 
 ## 全部标签
-<!-- material/tags -->  ← 自动生成部分
+&lt;!-- material/tags --&gt;  ← 自动生成部分
 ```
 
 **替代方案**：


### PR DESCRIPTION
## 摘要
- 将开发文档中的 `material/tags` 注释示例改为 HTML 实体，避免 MkDocs Material 误识别为真实标签索引页。
- 验证标签链接重新指向 `tags` 页面，解决标签跳转错误。

## 测试
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68e5bc35098c8333b1d62e329a6ac329